### PR TITLE
Update to Chromium 86.0.4240.198 & more patches

### DIFF
--- a/chromium.sh
+++ b/chromium.sh
@@ -27,4 +27,5 @@ if [[ -f "$XDG_CONFIG_HOME/chromium-flags.conf" ]]; then
 fi
 
 export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
+export CHROME_WRAPPER=$(readlink -f "$0")
 exec /app/chromium/chrome "$@"

--- a/org.chromium.Chromium.yaml
+++ b/org.chromium.Chromium.yaml
@@ -45,7 +45,7 @@ add-extensions:
     autodelete: true
 
   com.widevine.Widevine:
-    version: '1'
+    version: '4'
     directory: widevine
     autodelete: true
 
@@ -136,10 +136,17 @@ modules:
       - type: file
         path: krb5.conf
 
+  - name: flextop
+    buildsystem: meson
+    sources:
+      - type: git
+        url: https://github.com/refi64/flextop
+        commit: f0845f44e07739d3d1ba70a9f42fdfd0eb6947da
+
   - name: extensions
     buildsystem: simple
     build-commands:
-      - mkdir -p /app/native-messaging-hosts /app/widevine
+      - mkdir -p /app/native-messaging-hosts /app/policies /app/widevine
 
   - name: chromium
     buildsystem: simple
@@ -205,8 +212,8 @@ modules:
       - install -Dm 755 chromium.sh /app/bin/chromium
     sources:
       - type: archive
-        url: https://commondatastorage.googleapis.com/chromium-browser-official/chromium-86.0.4240.183.tar.xz
-        sha256: aa12c6665c33275f3edffb6f127f97f84fa0bb69c644b4b023d51d2d058a69bc
+        url: https://commondatastorage.googleapis.com/chromium-browser-official/chromium-86.0.4240.198.tar.xz
+        sha256: a0ab825e527becab4ab3e11ef889e842436fe11a4fb7874419d1970e680c7a44
       - type: patch
         paths:
           - patches/0001-ffmpeg-Use-royalty-free-libfdk-aac-for-AAC-playback.patch
@@ -227,6 +234,10 @@ modules:
           - patches/0016-XDG-file-chooser-portal-support.patch
           - patches/0017-Remove-dead-reloc-in-nonalloc-LD-flags.patch
           - patches/0018-XProto-Search-for-cursors-in-the-XDG-data-dirs.patch
+          - patches/0019-Remove-the-ability-to-create-desktop-shortcuts.patch
+          - patches/0020-webhid-Use-a-stub-where-there-is-no-OS-support.patch
+          - patches/0021-webusb-Don-t-reinitialize-a-failed-connection.patch
+          - patches/0022-Use-CHROME_WRAPPER-as-the-executable-on-restart.patch
       - type: file
         path: org.chromium.Chromium.desktop
       - type: file

--- a/patches/0006-Add-Flatpak-sandbox-support.patch
+++ b/patches/0006-Add-Flatpak-sandbox-support.patch
@@ -1,7 +1,7 @@
-From c39a4449a5e61ab63aa71d3d20f972279f387c1c Mon Sep 17 00:00:00 2001
+From 696903debb0a9a52dfc3988b7408efdff9e705c4 Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <rymg19@gmail.com>
 Date: Tue, 17 Mar 2020 13:18:27 -0500
-Subject: [PATCH 06/18] Add Flatpak sandbox support
+Subject: [PATCH 06/22] Add Flatpak sandbox support
 
 ---
  .gitignore                                    |   1 +

--- a/patches/0007-Use-Flatpak-specific-configuration-paths.patch
+++ b/patches/0007-Use-Flatpak-specific-configuration-paths.patch
@@ -1,7 +1,7 @@
-From f761ad1220bd5236d563c289a2278315e61253aa Mon Sep 17 00:00:00 2001
+From 632f9f233694bb61f16558def6d8b32966270250 Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <rymg19@gmail.com>
 Date: Tue, 25 Aug 2020 19:26:07 -0500
-Subject: [PATCH 07/18] Use Flatpak-specific configuration paths
+Subject: [PATCH 07/22] Use Flatpak-specific configuration paths
 
 ---
  chrome/common/BUILD.gn        |  4 ++++

--- a/patches/0008-Add-support-for-Flatpak-s-Widevine-location.patch
+++ b/patches/0008-Add-support-for-Flatpak-s-Widevine-location.patch
@@ -1,7 +1,7 @@
-From b5a918c41befb0395d60938e6bc34a15a238221d Mon Sep 17 00:00:00 2001
+From 3336ba582710ec8f8b1ea00ac32535a86114513c Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <rymg19@gmail.com>
 Date: Wed, 26 Aug 2020 20:23:56 -0500
-Subject: [PATCH 08/18] Add support for Flatpak's Widevine location
+Subject: [PATCH 08/22] Add support for Flatpak's Widevine location
 
 ---
  chrome/common/chrome_paths.cc | 9 ++++++---

--- a/patches/0009-Import-widevine-enable-version-string.patch-from-Ubu.patch
+++ b/patches/0009-Import-widevine-enable-version-string.patch-from-Ubu.patch
@@ -1,7 +1,7 @@
-From 621df61d773c6abda500433ae3162a05a250a91d Mon Sep 17 00:00:00 2001
+From 8f5f1a4d93b761aaa4c821ae5bda88f491103327 Mon Sep 17 00:00:00 2001
 From: Andre Moreira Magalhaes <andre@endlessm.com>
 Date: Fri, 10 Jul 2020 20:31:20 -0300
-Subject: [PATCH 09/18] Import widevine-enable-version-string.patch from Ubuntu
+Subject: [PATCH 09/22] Import widevine-enable-version-string.patch from Ubuntu
 
 ---
  chrome/common/chrome_content_client.cc          | 6 +++---

--- a/patches/0010-Enable-Chromecast-by-default.patch
+++ b/patches/0010-Enable-Chromecast-by-default.patch
@@ -1,7 +1,7 @@
-From 97ba6d0a7c8e64448b0b677b634e5f5a36db977f Mon Sep 17 00:00:00 2001
+From acf1a11d425747fd9ca57bae41a7250a2c900e17 Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <rymg19@gmail.com>
 Date: Wed, 26 Aug 2020 20:30:35 -0500
-Subject: [PATCH 10/18] Enable Chromecast by default
+Subject: [PATCH 10/22] Enable Chromecast by default
 
 ---
  extensions/common/feature_switch.cc | 14 ++++----------

--- a/patches/0011-x11-Set-_NET_WM_BYPASS_COMPOSITOR-for-fullscreen.patch
+++ b/patches/0011-x11-Set-_NET_WM_BYPASS_COMPOSITOR-for-fullscreen.patch
@@ -1,7 +1,7 @@
-From 31df2eebe82349671f6eecb11053bcf92c48c163 Mon Sep 17 00:00:00 2001
+From 901213ed5aa8bce5b3346c91b0370ea1eacf5b9a Mon Sep 17 00:00:00 2001
 From: Daniel Drake <drake@endlessm.com>
 Date: Fri, 3 Jul 2015 14:59:24 -0600
-Subject: [PATCH 11/18] x11: Set _NET_WM_BYPASS_COMPOSITOR for fullscreen
+Subject: [PATCH 11/22] x11: Set _NET_WM_BYPASS_COMPOSITOR for fullscreen
 
 This improves performance at full screen.
 ---

--- a/patches/0012-memory-Enable-the-tab-discards-feature.patch
+++ b/patches/0012-memory-Enable-the-tab-discards-feature.patch
@@ -1,7 +1,7 @@
-From f9593bcdc0efcda6896c6c95ada6787674da3a83 Mon Sep 17 00:00:00 2001
+From 677bf0d30afb507fae4cf61646d035654de85e49 Mon Sep 17 00:00:00 2001
 From: Mario Sanchez Prada <mario@endlessm.com>
 Date: Thu, 28 Jan 2016 13:53:08 +0000
-Subject: [PATCH 12/18] memory: Enable the tab discards feature
+Subject: [PATCH 12/22] memory: Enable the tab discards feature
 
 This allows manually discarding tabs from chrome://discards as well
 as automatic tab discards once a certain level of "memory pressure"

--- a/patches/0013-Add-memory-pressure-monitor-for-Linux.patch
+++ b/patches/0013-Add-memory-pressure-monitor-for-Linux.patch
@@ -1,7 +1,7 @@
-From b2dce0e797313b234b3abfa778aef1035aa6d8e8 Mon Sep 17 00:00:00 2001
+From ffa5afee16b8bf41e8abbab61ea3e8efe76eb961 Mon Sep 17 00:00:00 2001
 From: Kirill Ovchinnikov <kirill.ovchinn@gmail.com>
 Date: Thu, 27 Aug 2020 22:29:32 +0000
-Subject: [PATCH 13/18] Add memory pressure monitor for Linux.
+Subject: [PATCH 13/22] Add memory pressure monitor for Linux.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/patches/0014-Enable-VAVDA-VAVEA-and-VAJDA-on-linux-with-VAAPI-onl.patch
+++ b/patches/0014-Enable-VAVDA-VAVEA-and-VAJDA-on-linux-with-VAAPI-onl.patch
@@ -1,7 +1,7 @@
-From af252eded69aa8c83a0aae7d32827beecc99e769 Mon Sep 17 00:00:00 2001
+From 36c4698b90262d34818883288c0b0f97d50db923 Mon Sep 17 00:00:00 2001
 From: Lorenzo Tilve <ltilve@igalia.com>
 Date: Mon, 7 Oct 2019 13:45:14 +0200
-Subject: [PATCH 14/18] Enable VAVDA, VAVEA and VAJDA on linux with VAAPI only
+Subject: [PATCH 14/22] Enable VAVDA, VAVEA and VAJDA on linux with VAAPI only
 
 This patch contains all the changes necessary to use VA-API along with
 vaapi-driver to run all media use cases supported with hardware acceleration.

--- a/patches/0015-ffmpeg-Don-t-lie-about-AAC-and-H264-decoders-when-no.patch
+++ b/patches/0015-ffmpeg-Don-t-lie-about-AAC-and-H264-decoders-when-no.patch
@@ -1,7 +1,7 @@
-From 56eda1525066356e68395e565a0a25d0d30112be Mon Sep 17 00:00:00 2001
+From d39489e6ee114b3b9c516db6b35009b963a0faa0 Mon Sep 17 00:00:00 2001
 From: Mario Sanchez Prada <mario@endlessm.com>
 Date: Tue, 25 Oct 2016 16:57:00 +0000
-Subject: [PATCH 15/18] ffmpeg: Don't lie about AAC and H264 decoders when not
+Subject: [PATCH 15/22] ffmpeg: Don't lie about AAC and H264 decoders when not
  available
 
 On Endless OS, we always build with USE_PROPRIETARY_CODECS defined

--- a/patches/0016-XDG-file-chooser-portal-support.patch
+++ b/patches/0016-XDG-file-chooser-portal-support.patch
@@ -1,7 +1,7 @@
-From 7db034e2e7b0f18776e8556eb3d46a7b61ca06ec Mon Sep 17 00:00:00 2001
+From 01dceae68e42c2986e556b596d6b7908b4b7b09b Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <rymg19@gmail.com>
 Date: Mon, 31 Aug 2020 15:26:52 -0500
-Subject: [PATCH 16/18] XDG file chooser portal support
+Subject: [PATCH 16/22] XDG file chooser portal support
 
 ---
  chrome/browser/about_flags.cc             |   7 +

--- a/patches/0017-Remove-dead-reloc-in-nonalloc-LD-flags.patch
+++ b/patches/0017-Remove-dead-reloc-in-nonalloc-LD-flags.patch
@@ -1,7 +1,7 @@
-From fe1320282c71ae6fd58693d18a437e75f86c9f00 Mon Sep 17 00:00:00 2001
+From 7e7f0dbfffc676093ebd5be2e38eecbfd0cdc725 Mon Sep 17 00:00:00 2001
 From: Daniel Nicoara <dnicoara@chromium.org>
 Date: Thu, 24 Sep 2020 02:34:24 +0000
-Subject: [PATCH 17/18] Remove dead-reloc-in-nonalloc LD flags
+Subject: [PATCH 17/22] Remove dead-reloc-in-nonalloc LD flags
 
 Breakpad change landed. Revert workaround.
 

--- a/patches/0018-XProto-Search-for-cursors-in-the-XDG-data-dirs.patch
+++ b/patches/0018-XProto-Search-for-cursors-in-the-XDG-data-dirs.patch
@@ -1,7 +1,7 @@
-From cbdd14bb3c21c09795f210491e27abb01aa14119 Mon Sep 17 00:00:00 2001
+From fb90d5c61f8d6868f733eeab68893992570809e8 Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <rymg19@gmail.com>
 Date: Thu, 29 Oct 2020 12:00:35 -0500
-Subject: [PATCH 18/18] [XProto] Search for cursors in the XDG data dirs
+Subject: [PATCH 18/22] [XProto] Search for cursors in the XDG data dirs
 
 ---
  ui/base/x/x11_cursor_loader.cc | 51 +++++++++++++++++++++++++++-------

--- a/patches/0019-Remove-the-ability-to-create-desktop-shortcuts.patch
+++ b/patches/0019-Remove-the-ability-to-create-desktop-shortcuts.patch
@@ -1,0 +1,79 @@
+From 6e66ecec79f40a5b49cbc8df6c4c4d880411c86f Mon Sep 17 00:00:00 2001
+From: Ryan Gonzalez <rymg19@gmail.com>
+Date: Wed, 11 Nov 2020 16:51:49 -0600
+Subject: [PATCH 19/22] Remove the ability to create desktop shortcuts
+
+---
+ .../ui/views/create_application_shortcut_view.cc  | 15 +--------------
+ .../ui/views/create_application_shortcut_view.h   |  1 -
+ 2 files changed, 1 insertion(+), 15 deletions(-)
+
+diff --git a/chrome/browser/ui/views/create_application_shortcut_view.cc b/chrome/browser/ui/views/create_application_shortcut_view.cc
+index 7fdf7167de038..93f5240528dcb 100644
+--- a/chrome/browser/ui/views/create_application_shortcut_view.cc
++++ b/chrome/browser/ui/views/create_application_shortcut_view.cc
+@@ -109,10 +109,6 @@ void CreateChromeApplicationShortcutView::InitControls() {
+   create_shortcuts_label->SetHorizontalAlignment(gfx::ALIGN_LEFT);
+   create_shortcuts_label->SetMultiLine(true);
+ 
+-  std::unique_ptr<views::Checkbox> desktop_check_box = AddCheckbox(
+-      l10n_util::GetStringUTF16(IDS_CREATE_SHORTCUTS_DESKTOP_CHKBOX),
+-      profile_->GetPrefs()->GetBoolean(prefs::kWebAppCreateOnDesktop));
+-
+   std::unique_ptr<views::Checkbox> menu_check_box;
+   std::unique_ptr<views::Checkbox> quick_launch_check_box;
+ 
+@@ -168,7 +164,6 @@ void CreateChromeApplicationShortcutView::InitControls() {
+       views::GridLayout::kFixedSize,
+       provider->GetDistanceMetric(views::DISTANCE_RELATED_CONTROL_VERTICAL));
+   layout->StartRow(views::GridLayout::kFixedSize, kTableColumnSetId);
+-  desktop_check_box_ = layout->AddView(std::move(desktop_check_box));
+ 
+   const int vertical_spacing =
+       provider->GetDistanceMetric(DISTANCE_RELATED_CONTROL_VERTICAL_SMALL);
+@@ -203,10 +198,6 @@ bool CreateChromeApplicationShortcutView::IsDialogButtonEnabled(
+     // Dialog's not ready because app info hasn't been loaded.
+     return false;
+ 
+-  // One of the three location checkboxes must be checked:
+-  if (desktop_check_box_->GetChecked())
+-    return true;
+-
+   if (menu_check_box_ && menu_check_box_->GetChecked())
+     return true;
+ 
+@@ -235,7 +226,6 @@ void CreateChromeApplicationShortcutView::OnDialogAccepted() {
+     return;
+ 
+   web_app::ShortcutLocations creation_locations;
+-  creation_locations.on_desktop = desktop_check_box_->GetChecked();
+   if (menu_check_box_ && menu_check_box_->GetChecked()) {
+     creation_locations.applications_menu_location =
+         web_app::APP_MENU_LOCATION_SUBDIR_CHROMEAPPS;
+@@ -258,10 +248,7 @@ void CreateChromeApplicationShortcutView::OnDialogAccepted() {
+ void CreateChromeApplicationShortcutView::ButtonPressed(
+     views::Button* sender,
+     const ui::Event& event) {
+-  if (sender == desktop_check_box_) {
+-    profile_->GetPrefs()->SetBoolean(prefs::kWebAppCreateOnDesktop,
+-                                     desktop_check_box_->GetChecked());
+-  } else if (sender == menu_check_box_) {
++  if (sender == menu_check_box_) {
+     profile_->GetPrefs()->SetBoolean(prefs::kWebAppCreateInAppsMenu,
+                                      menu_check_box_->GetChecked());
+   } else if (sender == quick_launch_check_box_) {
+diff --git a/chrome/browser/ui/views/create_application_shortcut_view.h b/chrome/browser/ui/views/create_application_shortcut_view.h
+index 6250145b12856..95779c6c9d76c 100644
+--- a/chrome/browser/ui/views/create_application_shortcut_view.h
++++ b/chrome/browser/ui/views/create_application_shortcut_view.h
+@@ -71,7 +71,6 @@ class CreateChromeApplicationShortcutView : public views::DialogDelegateView,
+   base::Callback<void(bool)> close_callback_;
+ 
+   // May be null if the platform doesn't support a particular location.
+-  views::Checkbox* desktop_check_box_ = nullptr;
+   views::Checkbox* menu_check_box_ = nullptr;
+   views::Checkbox* quick_launch_check_box_ = nullptr;
+ 
+-- 
+2.26.2
+

--- a/patches/0020-webhid-Use-a-stub-where-there-is-no-OS-support.patch
+++ b/patches/0020-webhid-Use-a-stub-where-there-is-no-OS-support.patch
@@ -1,0 +1,145 @@
+From ea4244736170722826303ccf8065e196710bdb3e Mon Sep 17 00:00:00 2001
+From: Ryan Gonzalez <rymg19@gmail.com>
+Date: Wed, 11 Nov 2020 16:53:24 -0600
+Subject: [PATCH 20/22] [webhid] Use a stub where there is no OS support
+
+Without this, various sections of the code will crash when running on
+Linux without udev support.
+---
+ services/device/hid/BUILD.gn            | 19 +++++++++++++----
+ services/device/hid/hid_service.cc      |  4 +++-
+ services/device/hid/hid_service_stub.cc | 27 ++++++++++++++++++++++++
+ services/device/hid/hid_service_stub.h  | 28 +++++++++++++++++++++++++
+ 4 files changed, 73 insertions(+), 5 deletions(-)
+ create mode 100644 services/device/hid/hid_service_stub.cc
+ create mode 100644 services/device/hid/hid_service_stub.h
+
+diff --git a/services/device/hid/BUILD.gn b/services/device/hid/BUILD.gn
+index dbe298726895f..2d5454f6879af 100644
+--- a/services/device/hid/BUILD.gn
++++ b/services/device/hid/BUILD.gn
+@@ -27,10 +27,6 @@ source_set("hid") {
+     "hid_manager_impl.h",
+     "hid_service.cc",
+     "hid_service.h",
+-    "hid_service_mac.cc",
+-    "hid_service_mac.h",
+-    "hid_service_win.cc",
+-    "hid_service_win.h",
+   ]
+ 
+   deps = [
+@@ -49,6 +45,21 @@ source_set("hid") {
+       "input_service_linux.h",
+     ]
+     deps += [ "//device/udev_linux" ]
++  } else if (is_mac) {
++    sources += [
++      "hid_service_mac.cc",
++      "hid_service_mac.h",
++    ]
++  } else if (is_win) {
++    sources += [
++      "hid_service_win.cc",
++      "hid_service_win.h",
++    ]
++  } else {
++    sources += [
++      "hid_service_stub.cc",
++      "hid_service_stub.h",
++    ]
+   }
+ 
+   if (is_chromeos) {
+diff --git a/services/device/hid/hid_service.cc b/services/device/hid/hid_service.cc
+index 056c83b638dd7..7fe7fc25a4a59 100644
+--- a/services/device/hid/hid_service.cc
++++ b/services/device/hid/hid_service.cc
+@@ -20,6 +20,8 @@
+ #include "services/device/hid/hid_service_mac.h"
+ #elif defined(OS_WIN)
+ #include "services/device/hid/hid_service_win.h"
++#else
++#include "services/device/hid/hid_service_stub.h"
+ #endif
+ 
+ namespace device {
+@@ -41,7 +43,7 @@ std::unique_ptr<HidService> HidService::Create() {
+ #elif defined(OS_WIN)
+   return base::WrapUnique(new HidServiceWin());
+ #else
+-  return nullptr;
++  return base::WrapUnique(new HidServiceStub());
+ #endif
+ }
+ 
+diff --git a/services/device/hid/hid_service_stub.cc b/services/device/hid/hid_service_stub.cc
+new file mode 100644
+index 0000000000000..ddb97a4f61766
+--- /dev/null
++++ b/services/device/hid/hid_service_stub.cc
+@@ -0,0 +1,27 @@
++// Copyright 2020 The Chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "services/device/hid/hid_service_stub.h"
++
++#include "base/bind.h"
++#include "base/threading/sequenced_task_runner_handle.h"
++#include "services/device/hid/hid_connection.h"
++
++namespace device {
++
++HidServiceStub::HidServiceStub() = default;
++
++HidServiceStub::~HidServiceStub() = default;
++
++void HidServiceStub::Connect(const std::string& device_id,
++                             ConnectCallback callback) /*override*/ {
++  base::SequencedTaskRunnerHandle::Get()->PostTask(
++      FROM_HERE, base::BindOnce(std::move(callback), nullptr));
++}
++
++base::WeakPtr<HidService> HidServiceStub::GetWeakPtr() {
++  return weak_factory_.GetWeakPtr();
++}
++
++}  // namespace device
+diff --git a/services/device/hid/hid_service_stub.h b/services/device/hid/hid_service_stub.h
+new file mode 100644
+index 0000000000000..f9ab184551d02
+--- /dev/null
++++ b/services/device/hid/hid_service_stub.h
+@@ -0,0 +1,28 @@
++// Copyright 2020 The Chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef SERVICES_DEVICE_HID_HID_SERVICE_STUB_H_
++#define SERVICES_DEVICE_HID_HID_SERVICE_STUB_H_
++
++#include "base/memory/weak_ptr.h"
++#include "services/device/hid/hid_service.h"
++
++namespace device {
++
++class HidServiceStub : public HidService {
++ public:
++  HidServiceStub();
++  ~HidServiceStub() override;
++
++  // HidService:
++  void Connect(const std::string& device_id, ConnectCallback callback) override;
++  base::WeakPtr<HidService> GetWeakPtr() override;
++
++ private:
++  base::WeakPtrFactory<HidServiceStub> weak_factory_{this};
++};
++
++}  // namespace device
++
++#endif
+-- 
+2.26.2
+

--- a/patches/0021-webusb-Don-t-reinitialize-a-failed-connection.patch
+++ b/patches/0021-webusb-Don-t-reinitialize-a-failed-connection.patch
@@ -1,0 +1,27 @@
+From e530708102631e15f862beaec76288ef68f5dad4 Mon Sep 17 00:00:00 2001
+From: Ryan Gonzalez <rymg19@gmail.com>
+Date: Wed, 11 Nov 2020 16:54:18 -0600
+Subject: [PATCH 21/22] [webusb] Don't reinitialize a failed connection
+
+This is a hack that should be removed, but it appears that this will
+continuously loop over and over again on Linux without udev.
+---
+ chrome/browser/usb/web_usb_detector.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/chrome/browser/usb/web_usb_detector.cc b/chrome/browser/usb/web_usb_detector.cc
+index 6a55bca80172f..07b7fd5c81752 100644
+--- a/chrome/browser/usb/web_usb_detector.cc
++++ b/chrome/browser/usb/web_usb_detector.cc
+@@ -274,7 +274,7 @@ void WebUsbDetector::OnDeviceManagerConnectionError() {
+   client_receiver_.reset();
+ 
+   // Try to reconnect the device manager.
+-  Initialize();
++  // Initialize();
+ }
+ 
+ void WebUsbDetector::SetDeviceManagerForTesting(
+-- 
+2.26.2
+

--- a/patches/0022-Use-CHROME_WRAPPER-as-the-executable-on-restart.patch
+++ b/patches/0022-Use-CHROME_WRAPPER-as-the-executable-on-restart.patch
@@ -1,0 +1,40 @@
+From 83d268259d3b3c4617e649ae98843563101d13cd Mon Sep 17 00:00:00 2001
+From: Ryan Gonzalez <rymg19@gmail.com>
+Date: Wed, 11 Nov 2020 17:13:38 -0600
+Subject: [PATCH 22/22] Use CHROME_WRAPPER as the executable on restart
+
+---
+ chrome/browser/first_run/upgrade_util_linux.cc | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/chrome/browser/first_run/upgrade_util_linux.cc b/chrome/browser/first_run/upgrade_util_linux.cc
+index eef5298de4043..1ea121c1db404 100644
+--- a/chrome/browser/first_run/upgrade_util_linux.cc
++++ b/chrome/browser/first_run/upgrade_util_linux.cc
+@@ -12,6 +12,7 @@
+ #include "base/path_service.h"
+ #include "base/process/launch.h"
+ #include "chrome/browser/first_run/upgrade_util_linux.h"
++#include "chrome/browser/shell_integration_linux.h"
+ 
+ namespace {
+ 
+@@ -22,10 +23,14 @@ double saved_last_modified_time_of_exe = 0;
+ namespace upgrade_util {
+ 
+ bool RelaunchChromeBrowserImpl(const base::CommandLine& command_line) {
++  base::CommandLine new_cl(command_line);
++  // TODO: move the code outside the internal namespace.
++  new_cl.SetProgram(shell_integration_linux::internal::GetChromeExePath());
++
+   base::LaunchOptions options;
+   // Don't set NO_NEW_PRIVS on the relaunched browser process.
+   options.allow_new_privs = true;
+-  return base::LaunchProcess(command_line, options).IsValid();
++  return base::LaunchProcess(new_cl, options).IsValid();
+ }
+ 
+ bool IsUpdatePendingRestart() {
+-- 
+2.26.2
+


### PR DESCRIPTION
This adds:
- Experimental desktop shortcut support with flextop
- Widevine extension point tweaks in line with the official ABI
- Tries to fix the hanging process issue
- Fixes chrome://restart