### PR TITLE
Try enabling new-dtags to fix FFmpeg

### DIFF
--- a/org.chromium.Chromium.yaml
+++ b/org.chromium.Chromium.yaml
@@ -254,6 +254,7 @@ modules:
           - patches/0019-Add-support-for-the-XDG-file-chooser-portal.patch
           - patches/0020-Add-OpenURI-portal-support-for-opening-directories.patch
           - patches/0021-Remove-references-to-enable-dse-memoryssa.patch
+          - patches/0022-Enable-new-dtags-on-non-component-builds.patch
       - type: file
         path: org.chromium.Chromium.desktop
       - type: file

--- a/patches/0022-Enable-new-dtags-on-non-component-builds.patch
+++ b/patches/0022-Enable-new-dtags-on-non-component-builds.patch
@@ -1,0 +1,46 @@
+From 086f0c1cf1d207ddbd579e99f41e39793dbc48f1 Mon Sep 17 00:00:00 2001
+From: Ryan Gonzalez <rymg19@gmail.com>
+Date: Thu, 19 Nov 2020 16:20:05 -0600
+Subject: [PATCH 22/22] Enable new-dtags on non-component builds
+
+---
+ build/config/gcc/BUILD.gn | 23 ++++++++++++++++-------
+ 1 file changed, 16 insertions(+), 7 deletions(-)
+
+diff --git a/build/config/gcc/BUILD.gn b/build/config/gcc/BUILD.gn
+index 154b259b5faea..e8be9ca824ca7 100644
+--- a/build/config/gcc/BUILD.gn
++++ b/build/config/gcc/BUILD.gn
+@@ -100,13 +100,22 @@ config("executable_config") {
+   }
+ 
+   if (!is_android && current_os != "aix") {
+-    ldflags += [
+-      # TODO(GYP): Do we need a check on the binutils version here?
+-      #
+-      # Newer binutils don't set DT_RPATH unless you disable "new" dtags
+-      # and the new DT_RUNPATH doesn't work without --no-as-needed flag.
+-      "-Wl,--disable-new-dtags",
+-    ]
++    if (is_component_build) {
++      ldflags += [
++        # TODO(GYP): Do we need a check on the binutils version here?
++        #
++        # Newer binutils don't set DT_RPATH unless you disable "new" dtags
++        # and the new DT_RUNPATH doesn't work without --no-as-needed flag.
++        "-Wl,--disable-new-dtags",
++      ]
++    } else {
++      # Using DT_RUNPATH breaks the component builds, because RUNPATH isn't used
++      # to look up transitive dependencies like RPATH is, but it's fine for
++      # primarily static builds.
++      ldflags += [
++        "-Wl,--enable-new-dtags"
++      ]
++    }
+   }
+ }
+ 
+-- 
+2.26.2
+


### PR DESCRIPTION
new-dtags will use DT_RUNPATH instead of DT_RPATH, which means that
LD_LIBRARY_PATH will be given higher priority. This breaks standard
component builds, since DT_RUNPATH isn't used to resolve transitive
dependencies, but that doesn't matter for our static release builds.

Closes #15.