### PR TITLE
Fix FFmpeg, and various other fixes

### DIFF
--- a/org.chromium.Chromium.metainfo.xml
+++ b/org.chromium.Chromium.metainfo.xml
@@ -26,6 +26,11 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="87.0.4280.66" date="2020-11-18" />
+    <release version="86.0.4240.198" date="2020-11-12" />
+    <release version="86.0.4240.183" date="2020-11-02" />
+    <release version="86.0.4240.111" date="2020-11-01" />
+    <release version="86.0.4240.75" date="2020-10-15" />
     <release version="85.0.4183.121" date="2020-09-29" />
   </releases>
   <content_rating type="oars-1.1" />

--- a/org.chromium.Chromium.yaml
+++ b/org.chromium.Chromium.yaml
@@ -8,6 +8,7 @@ finish-args:
   - --filesystem=home
   - --device=all
   - --env=GTK_PATH=/app/lib/gtkmodules
+  - --env=LD_LIBRARY_PATH=/app/chromium/nonfree-codecs/lib
   - --share=ipc
   - --share=network
   - --socket=cups
@@ -31,32 +32,24 @@ add-extensions:
 
   org.chromium.Chromium.NativeMessagingHost:
     version: '1'
-    directory: native-messaging-hosts
-    merge-dirs: manifest
+    directory: chromium/native-messaging-hosts
+    merge-dirs: native-messaging-hosts
     subdirectories: true
     no-autodownload: true
     autodelete: true
 
   org.chromium.Chromium.Extension:
     version: '1'
-    directory: extensions
-    merge-dirs: manifest
+    directory: chromium/extensions
+    merge-dirs: extensions
     subdirectories: true
     no-autodownload: true
     autodelete: true
 
-  org.chromium.Chromium.Policy.Managed:
+  org.chromium.Chromium.Policy:
     version: '1'
-    directory: policies/managed
-    merge-dirs: policy
-    subdirectories: true
-    no-autodownload: true
-    autodelete: true
-
-  org.chromium.Chromium.Policy.Recommended:
-    version: '1'
-    directory: policies/recommended
-    merge-dirs: policy
+    directory: chromium/policies
+    merge-dirs: policies/managed;policies/recommended
     subdirectories: true
     no-autodownload: true
     autodelete: true
@@ -158,11 +151,7 @@ modules:
   - name: extensions
     buildsystem: simple
     build-commands:
-      - >
-        mkdir -p
-        /app/extensions
-        /app/native-messaging-hosts
-        /app/policies/{managed,recommended}
+      - mkdir -p /app/chromium/{extensions,native-messaging-hosts,policies}
 
   - name: chromium
     buildsystem: simple
@@ -254,6 +243,7 @@ modules:
           - patches/0019-Add-support-for-the-XDG-file-chooser-portal.patch
           - patches/0020-Add-OpenURI-portal-support-for-opening-directories.patch
           - patches/0021-Remove-references-to-enable-dse-memoryssa.patch
+          - patches/0022-Enable-new-dtags-on-non-component-builds.patch
       - type: file
         path: org.chromium.Chromium.desktop
       - type: file

--- a/patches/0006-flatpak-Add-initial-sandbox-support.patch
+++ b/patches/0006-flatpak-Add-initial-sandbox-support.patch
@@ -1,7 +1,7 @@
 From d3959eb4525af4226a283e3199d6fbe8f5f8f3b5 Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <rymg19@gmail.com>
 Date: Tue, 17 Mar 2020 13:18:27 -0500
-Subject: [PATCH 06/21] flatpak: Add initial sandbox support
+Subject: [PATCH 06/22] flatpak: Add initial sandbox support
 
 ---
  .gitignore                                    |   1 +

--- a/patches/0007-flatpak-Expose-Widevine-into-the-sandbox.patch
+++ b/patches/0007-flatpak-Expose-Widevine-into-the-sandbox.patch
@@ -1,7 +1,7 @@
 From 60b391c5a48f3b58bb322fe28f1ca1cea03b71f9 Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <rymg19@gmail.com>
 Date: Tue, 17 Nov 2020 13:00:39 -0600
-Subject: [PATCH 07/21] flatpak: Expose Widevine into the sandbox
+Subject: [PATCH 07/22] flatpak: Expose Widevine into the sandbox
 
 ---
  .../zygote_host/zygote_host_impl_linux.cc     | 54 +++++++++++++-

--- a/patches/0008-flatpak-Adjust-paths-for-the-sandbox.patch
+++ b/patches/0008-flatpak-Adjust-paths-for-the-sandbox.patch
@@ -1,15 +1,12 @@
-From c3c11f616be5f1f344298d0460111bdb1c619e6b Mon Sep 17 00:00:00 2001
+From 47cae042bfe5d9bef7073702cb20df56c711442a Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <rymg19@gmail.com>
 Date: Tue, 25 Aug 2020 19:26:07 -0500
-Subject: [PATCH 08/21] flatpak: Adjust paths for the sandbox
+Subject: [PATCH 08/22] flatpak: Adjust paths for the sandbox
 
 ---
- chrome/common/BUILD.gn                        |  4 ++
- chrome/common/chrome_paths.cc                 | 50 +++++++++++++------
- components/policy/core/common/BUILD.gn        |  3 ++
- .../core/common/config_dir_policy_loader.cc   | 32 ++++++++++--
- .../core/common/config_dir_policy_loader.h    |  3 ++
- 5 files changed, 73 insertions(+), 19 deletions(-)
+ chrome/common/BUILD.gn        |  4 +++
+ chrome/common/chrome_paths.cc | 52 +++++++++++++++++++++++++----------
+ 2 files changed, 42 insertions(+), 14 deletions(-)
 
 diff --git a/chrome/common/BUILD.gn b/chrome/common/BUILD.gn
 index 52ae4877ab7bd..da3ea85370192 100644
@@ -27,7 +24,7 @@ index 52ae4877ab7bd..da3ea85370192 100644
  
  # Use a static library here because many test binaries depend on this but don't
 diff --git a/chrome/common/chrome_paths.cc b/chrome/common/chrome_paths.cc
-index 26dc3fc1cafa8..eb273f9133f68 100644
+index 26dc3fc1cafa8..bbe0a53fb54dd 100644
 --- a/chrome/common/chrome_paths.cc
 +++ b/chrome/common/chrome_paths.cc
 @@ -4,6 +4,7 @@
@@ -69,35 +66,37 @@ index 26dc3fc1cafa8..eb273f9133f68 100644
        break;
  #elif defined(OS_ANDROID)
        if (!base::PathService::Get(ui::DIR_RESOURCE_PAKS_ANDROID, &cur))
-@@ -492,6 +497,13 @@ bool PathProvider(int key, base::FilePath* result) {
+@@ -492,6 +497,14 @@ bool PathProvider(int key, base::FilePath* result) {
        break;
  #if defined(OS_POSIX) && !defined(OS_MAC) && !defined(OS_OPENBSD)
      case chrome::DIR_POLICY_FILES: {
 +#if defined(OS_LINUX)
 +      if (sandbox::FlatpakSandbox::GetInstance()->GetSandboxLevel() >
 +          sandbox::FlatpakSandbox::SandboxLevel::kNone) {
-+        cur = base::FilePath(FILE_PATH_LITERAL("/app/policies"));
++        cur = base::FilePath(
++            FILE_PATH_LITERAL("/app/chromium/policies/policies"));
 +        break;
 +      }
 +#endif
  #if BUILDFLAG(GOOGLE_CHROME_BRANDING)
        cur = base::FilePath(FILE_PATH_LITERAL("/etc/opt/chrome/policies"));
  #else
-@@ -511,7 +523,12 @@ bool PathProvider(int key, base::FilePath* result) {
+@@ -511,7 +524,13 @@ bool PathProvider(int key, base::FilePath* result) {
  #endif
  #if defined(OS_LINUX) || defined(OS_CHROMEOS)
      case chrome::DIR_STANDALONE_EXTERNAL_EXTENSIONS: {
 -      cur = base::FilePath(kFilepathSinglePrefExtensions);
 +      if (sandbox::FlatpakSandbox::GetInstance()->GetSandboxLevel() >
 +          sandbox::FlatpakSandbox::SandboxLevel::kNone) {
-+        cur = base::FilePath(FILE_PATH_LITERAL("/app/extensions/manifest"));
++        cur = base::FilePath(
++            FILE_PATH_LITERAL("/app/chromium/extensions/extensions"));
 +      } else {
 +        cur = base::FilePath(kFilepathSinglePrefExtensions);
 +      }
        break;
      }
  #endif
-@@ -521,8 +538,8 @@ bool PathProvider(int key, base::FilePath* result) {
+@@ -521,8 +540,8 @@ bool PathProvider(int key, base::FilePath* result) {
          return false;
  
        cur = cur.Append(FILE_PATH_LITERAL("Google"))
@@ -108,7 +107,7 @@ index 26dc3fc1cafa8..eb273f9133f68 100644
        create_dir = false;
  #else
        if (!base::PathService::Get(base::DIR_MODULE, &cur))
-@@ -548,19 +565,25 @@ bool PathProvider(int key, base::FilePath* result) {
+@@ -548,19 +567,25 @@ bool PathProvider(int key, base::FilePath* result) {
      case chrome::DIR_NATIVE_MESSAGING:
  #if defined(OS_MAC)
  #if BUILDFLAG(GOOGLE_CHROME_BRANDING)
@@ -123,8 +122,8 @@ index 26dc3fc1cafa8..eb273f9133f68 100644
  #else  // defined(OS_MAC)
 +      if (sandbox::FlatpakSandbox::GetInstance()->GetSandboxLevel() >
 +          sandbox::FlatpakSandbox::SandboxLevel::kNone) {
-+        cur = base::FilePath(
-+            FILE_PATH_LITERAL("/app/native-messaging-hosts/manifest"));
++        cur = base::FilePath(FILE_PATH_LITERAL(
++            "/app/chromium/native-messaging-hosts/native-messaging-hosts"));
 +        break;
 +      }
  #if BUILDFLAG(GOOGLE_CHROME_BRANDING)
@@ -140,7 +139,7 @@ index 26dc3fc1cafa8..eb273f9133f68 100644
  #endif
  #endif  // !defined(OS_MAC)
        break;
-@@ -608,8 +631,7 @@ bool PathProvider(int key, base::FilePath* result) {
+@@ -608,8 +633,7 @@ bool PathProvider(int key, base::FilePath* result) {
  
    // TODO(bauerb): http://crbug.com/259796
    base::ThreadRestrictions::ScopedAllowIO allow_io;
@@ -150,113 +149,6 @@ index 26dc3fc1cafa8..eb273f9133f68 100644
      return false;
  
    *result = cur;
-diff --git a/components/policy/core/common/BUILD.gn b/components/policy/core/common/BUILD.gn
-index 43ffb518e3a84..86350818f4609 100644
---- a/components/policy/core/common/BUILD.gn
-+++ b/components/policy/core/common/BUILD.gn
-@@ -267,6 +267,9 @@ source_set("internal") {
-       "cloud/user_cloud_policy_store.h",
-     ]
-   }
-+  if (is_linux) {
-+    deps += [ "//sandbox/linux:sandbox_services" ]
-+  }
-   if (is_apple) {
-     sources += [
-       "mac_util.cc",
-diff --git a/components/policy/core/common/config_dir_policy_loader.cc b/components/policy/core/common/config_dir_policy_loader.cc
-index 457d97cf107ae..f7c9b2c8c6bb5 100644
---- a/components/policy/core/common/config_dir_policy_loader.cc
-+++ b/components/policy/core/common/config_dir_policy_loader.cc
-@@ -22,6 +22,10 @@
- #include "components/policy/core/common/policy_load_status.h"
- #include "components/policy/core/common/policy_types.h"
- 
-+#if defined(OS_LINUX)
-+#include "sandbox/linux/services/flatpak_sandbox.h"
-+#endif
-+
- namespace policy {
- 
- namespace {
-@@ -31,6 +35,11 @@ constexpr base::FilePath::CharType kMandatoryConfigDir[] =
-     FILE_PATH_LITERAL("managed");
- constexpr base::FilePath::CharType kRecommendedConfigDir[] =
-     FILE_PATH_LITERAL("recommended");
-+  
-+#if defined(OS_LINUX)
-+constexpr base::FilePath::CharType kFlatpakConfigSuffix[] =
-+    FILE_PATH_LITERAL("policy");
-+#endif
- 
- PolicyLoadStatus JsonErrorToPolicyLoadStatus(int status) {
-   switch (status) {
-@@ -67,18 +76,18 @@ void ConfigDirPolicyLoader::InitOnBackgroundThread() {
-   DCHECK(task_runner_->RunsTasksInCurrentSequence());
-   base::FilePathWatcher::Callback callback = base::BindRepeating(
-       &ConfigDirPolicyLoader::OnFileUpdated, base::Unretained(this));
--  mandatory_watcher_.Watch(config_dir_.Append(kMandatoryConfigDir), false,
-+  mandatory_watcher_.Watch(GetPolicySubdir(kMandatoryConfigDir), false,
-                            callback);
--  recommended_watcher_.Watch(config_dir_.Append(kRecommendedConfigDir), false,
-+  recommended_watcher_.Watch(GetPolicySubdir(kRecommendedConfigDir), false,
-                              callback);
- }
- 
- std::unique_ptr<PolicyBundle> ConfigDirPolicyLoader::Load() {
-   std::unique_ptr<PolicyBundle> bundle(new PolicyBundle());
--  LoadFromPath(config_dir_.Append(kMandatoryConfigDir),
-+  LoadFromPath(GetPolicySubdir(kMandatoryConfigDir),
-                POLICY_LEVEL_MANDATORY,
-                bundle.get());
--  LoadFromPath(config_dir_.Append(kRecommendedConfigDir),
-+  LoadFromPath(GetPolicySubdir(kRecommendedConfigDir),
-                POLICY_LEVEL_RECOMMENDED,
-                bundle.get());
-   return bundle;
-@@ -93,7 +102,7 @@ base::Time ConfigDirPolicyLoader::LastModificationTime() {
-   base::File::Info info;
- 
-   for (size_t i = 0; i < base::size(kConfigDirSuffixes); ++i) {
--    base::FilePath path(config_dir_.Append(kConfigDirSuffixes[i]));
-+    base::FilePath path(GetPolicySubdir(kConfigDirSuffixes[i]));
- 
-     // Skip if the file doesn't exist, or it isn't a directory.
-     if (!base::GetFileInfo(path, &info) || !info.is_directory)
-@@ -113,6 +122,19 @@ base::Time ConfigDirPolicyLoader::LastModificationTime() {
-   return last_modification;
- }
- 
-+base::FilePath ConfigDirPolicyLoader::GetPolicySubdir(
-+    const base::FilePath::CharType* subdir) {
-+  base::FilePath result = config_dir_.Append(subdir);
-+#if defined(OS_LINUX)
-+  // This is a bad place for this code!
-+  if (sandbox::FlatpakSandbox::GetInstance()->GetSandboxLevel() >
-+      sandbox::FlatpakSandbox::SandboxLevel::kNone) {
-+      result = result.Append(kFlatpakConfigSuffix);
-+  }
-+#endif
-+  return result;
-+}
-+
- void ConfigDirPolicyLoader::LoadFromPath(const base::FilePath& path,
-                                          PolicyLevel level,
-                                          PolicyBundle* bundle) {
-diff --git a/components/policy/core/common/config_dir_policy_loader.h b/components/policy/core/common/config_dir_policy_loader.h
-index 934ed4f1cd9d9..21fff7ceef0cc 100644
---- a/components/policy/core/common/config_dir_policy_loader.h
-+++ b/components/policy/core/common/config_dir_policy_loader.h
-@@ -37,6 +37,9 @@ class POLICY_EXPORT ConfigDirPolicyLoader : public AsyncPolicyLoader {
-   base::Time LastModificationTime() override;
- 
-  private:
-+  // Gets a policy subdirectory of the main config directory.
-+  base::FilePath GetPolicySubdir(const base::FilePath::CharType* subdir);
-+
-   // Loads the policy files at |path| into the |bundle|, with the given |level|.
-   void LoadFromPath(const base::FilePath& path,
-                     PolicyLevel level,
 -- 
 2.26.2
 

--- a/patches/0009-Import-chromium-71.0.3578.98-widevine-r3.patch.patch
+++ b/patches/0009-Import-chromium-71.0.3578.98-widevine-r3.patch.patch
@@ -1,7 +1,7 @@
-From 61c7a26dfe39485ade386bbe3cafff9e8c4e677e Mon Sep 17 00:00:00 2001
+From 267dc09c0b3aab635ba3fd3a47edc9111c4341b4 Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <rymg19@gmail.com>
 Date: Tue, 17 Nov 2020 22:57:29 -0600
-Subject: [PATCH 09/21] Import chromium-71.0.3578.98-widevine-r3.patch
+Subject: [PATCH 09/22] Import chromium-71.0.3578.98-widevine-r3.patch
 
 Taken from the Fedora 33 repositories.
 ---

--- a/patches/0010-Enable-Chromecast-by-default.patch
+++ b/patches/0010-Enable-Chromecast-by-default.patch
@@ -1,7 +1,7 @@
-From 6768a9b1d1d4347ad153e0fd588f13d95d307ead Mon Sep 17 00:00:00 2001
+From bb1e032ad759f4f1d620d8daa6db828699145155 Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <rymg19@gmail.com>
 Date: Wed, 26 Aug 2020 20:30:35 -0500
-Subject: [PATCH 10/21] Enable Chromecast by default
+Subject: [PATCH 10/22] Enable Chromecast by default
 
 ---
  extensions/common/feature_switch.cc | 14 ++++----------

--- a/patches/0011-x11-Set-_NET_WM_BYPASS_COMPOSITOR-for-fullscreen.patch
+++ b/patches/0011-x11-Set-_NET_WM_BYPASS_COMPOSITOR-for-fullscreen.patch
@@ -1,7 +1,7 @@
-From d1359ce523583e0ac4bf3828dda9a85b24f5ac02 Mon Sep 17 00:00:00 2001
+From 2be8e68d22447a0a55db8558e7ddee83222d7f27 Mon Sep 17 00:00:00 2001
 From: Daniel Drake <drake@endlessm.com>
 Date: Fri, 3 Jul 2015 14:59:24 -0600
-Subject: [PATCH 11/21] x11: Set _NET_WM_BYPASS_COMPOSITOR for fullscreen
+Subject: [PATCH 11/22] x11: Set _NET_WM_BYPASS_COMPOSITOR for fullscreen
 
 This improves performance at full screen.
 ---

--- a/patches/0012-memory-Enable-the-tab-discards-feature.patch
+++ b/patches/0012-memory-Enable-the-tab-discards-feature.patch
@@ -1,7 +1,7 @@
-From 57d7d1a3046e0823beea5c23c41a21a27b2839d5 Mon Sep 17 00:00:00 2001
+From fa387da2f416667b14de57686ab55489d3325677 Mon Sep 17 00:00:00 2001
 From: Mario Sanchez Prada <mario@endlessm.com>
 Date: Thu, 28 Jan 2016 13:53:08 +0000
-Subject: [PATCH 12/21] memory: Enable the tab discards feature
+Subject: [PATCH 12/22] memory: Enable the tab discards feature
 
 This allows manually discarding tabs from chrome://discards as well
 as automatic tab discards once a certain level of "memory pressure"

--- a/patches/0013-Enable-VAVDA-VAVEA-and-VAJDA-on-linux-with-VAAPI-onl.patch
+++ b/patches/0013-Enable-VAVDA-VAVEA-and-VAJDA-on-linux-with-VAAPI-onl.patch
@@ -1,7 +1,7 @@
-From 6f0b40c2e7bf6f7d21fc82249039536239c09289 Mon Sep 17 00:00:00 2001
+From 353c1b9fba2bf9a49fc34204ee3147a136a3f00a Mon Sep 17 00:00:00 2001
 From: Lorenzo Tilve <ltilve@igalia.com>
 Date: Mon, 7 Oct 2019 13:45:14 +0200
-Subject: [PATCH 13/21] Enable VAVDA, VAVEA and VAJDA on linux with VAAPI only
+Subject: [PATCH 13/22] Enable VAVDA, VAVEA and VAJDA on linux with VAAPI only
 
 This patch contains all the changes necessary to use VA-API along with
 vaapi-driver to run all media use cases supported with hardware acceleration.

--- a/patches/0014-ffmpeg-Don-t-lie-about-AAC-and-H264-decoders-when-no.patch
+++ b/patches/0014-ffmpeg-Don-t-lie-about-AAC-and-H264-decoders-when-no.patch
@@ -1,7 +1,7 @@
-From aa01f92d3b1148ea74eb74516de67c3c2be069d1 Mon Sep 17 00:00:00 2001
+From 694308d32ea8677678cb014e50346c8726be1dbe Mon Sep 17 00:00:00 2001
 From: Mario Sanchez Prada <mario@endlessm.com>
 Date: Tue, 25 Oct 2016 16:57:00 +0000
-Subject: [PATCH 14/21] ffmpeg: Don't lie about AAC and H264 decoders when not
+Subject: [PATCH 14/22] ffmpeg: Don't lie about AAC and H264 decoders when not
  available
 
 On Endless OS, we always build with USE_PROPRIETARY_CODECS defined

--- a/patches/0015-Remove-the-ability-to-create-desktop-shortcuts.patch
+++ b/patches/0015-Remove-the-ability-to-create-desktop-shortcuts.patch
@@ -1,12 +1,13 @@
-From 173a423cbe44b07e912de0a8bd9f421873f91b98 Mon Sep 17 00:00:00 2001
+From 30a48810e23ac7239bdf89cb2b8f905bc1f39c63 Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <rymg19@gmail.com>
 Date: Wed, 11 Nov 2020 16:51:49 -0600
-Subject: [PATCH 15/21] Remove the ability to create desktop shortcuts
+Subject: [PATCH 15/22] Remove the ability to create desktop shortcuts
 
 ---
- .../ui/views/create_application_shortcut_view.cc  | 15 +--------------
- .../ui/views/create_application_shortcut_view.h   |  1 -
- 2 files changed, 1 insertion(+), 15 deletions(-)
+ .../views/create_application_shortcut_view.cc | 15 +---
+ .../views/create_application_shortcut_view.h  |  1 -
+ .../components/web_app_shortcut_linux.cc      | 78 +------------------
+ 3 files changed, 2 insertions(+), 92 deletions(-)
 
 diff --git a/chrome/browser/ui/views/create_application_shortcut_view.cc b/chrome/browser/ui/views/create_application_shortcut_view.cc
 index 7015af5f4d731..d970ac0b102d9 100644
@@ -74,6 +75,136 @@ index 6250145b12856..95779c6c9d76c 100644
    views::Checkbox* menu_check_box_ = nullptr;
    views::Checkbox* quick_launch_check_box_ = nullptr;
  
+diff --git a/chrome/browser/web_applications/components/web_app_shortcut_linux.cc b/chrome/browser/web_applications/components/web_app_shortcut_linux.cc
+index 9b3ea698096da..97e0d6a482041 100644
+--- a/chrome/browser/web_applications/components/web_app_shortcut_linux.cc
++++ b/chrome/browser/web_applications/components/web_app_shortcut_linux.cc
+@@ -143,51 +143,6 @@ std::string CreateShortcutIcon(const gfx::ImageFamily& icon_images,
+   return icon_name;
+ }
+ 
+-bool CreateShortcutOnDesktop(const base::FilePath& shortcut_filename,
+-                             const std::string& contents) {
+-  // Make sure that we will later call openat in a secure way.
+-  DCHECK_EQ(shortcut_filename.BaseName().value(), shortcut_filename.value());
+-
+-  base::FilePath desktop_path;
+-  if (!base::PathService::Get(base::DIR_USER_DESKTOP, &desktop_path)) {
+-    RecordCreateShortcut(CreateShortcutResult::kFailToGetDesktopPath);
+-    return false;
+-  }
+-
+-  int desktop_fd = open(desktop_path.value().c_str(), O_RDONLY | O_DIRECTORY);
+-  if (desktop_fd < 0) {
+-    RecordCreateShortcut(CreateShortcutResult::kFailToOpenDesktopDir);
+-    return false;
+-  }
+-
+-  int fd = openat(desktop_fd, shortcut_filename.value().c_str(),
+-                  O_CREAT | O_EXCL | O_WRONLY,
+-                  S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
+-  if (fd < 0) {
+-    if (IGNORE_EINTR(close(desktop_fd)) < 0)
+-      PLOG(ERROR) << "close";
+-    RecordCreateShortcut(CreateShortcutResult::kFailToOpenShortcutFilepath);
+-    return false;
+-  }
+-
+-  if (!base::WriteFileDescriptor(fd, contents.c_str(), contents.size())) {
+-    // Delete the file. No shortuct is better than corrupted one. Use unlinkat
+-    // to make sure we're deleting the file in the directory we think we are.
+-    // Even if an attacker manager to put something other at
+-    // |shortcut_filename| we'll just undo their action.
+-    RecordCreateShortcut(CreateShortcutResult::kCorruptDesktopShortcut);
+-    unlinkat(desktop_fd, shortcut_filename.value().c_str(), 0);
+-  }
+-
+-  if (IGNORE_EINTR(close(fd)) < 0)
+-    PLOG(ERROR) << "close";
+-
+-  if (IGNORE_EINTR(close(desktop_fd)) < 0)
+-    PLOG(ERROR) << "close";
+-
+-  return true;
+-}
+-
+ // Creates a shortcut with |shortcut_filename| and |contents| in the system
+ // applications menu. If |directory_filename| is non-empty, creates a sub-menu
+ // with |directory_filename| and |directory_contents|, and stores the shortcut
+@@ -281,14 +236,6 @@ base::FilePath GetAppShortcutFilename(const base::FilePath& profile_path,
+   return base::FilePath(filename.append(".desktop"));
+ }
+ 
+-bool DeleteShortcutOnDesktop(const base::FilePath& shortcut_filename) {
+-  base::FilePath desktop_path;
+-  bool result = false;
+-  if (base::PathService::Get(base::DIR_USER_DESKTOP, &desktop_path))
+-    result = base::DeleteFile(desktop_path.Append(shortcut_filename));
+-  return result;
+-}
+-
+ bool DeleteShortcutInApplicationsMenu(
+     const base::FilePath& shortcut_filename,
+     const base::FilePath& directory_filename) {
+@@ -322,9 +269,6 @@ bool CreateDesktopShortcut(const ShortcutInfo& shortcut_info,
+                                                shortcut_info.extension_id);
+     // For extensions we do not want duplicate shortcuts. So, delete any that
+     // already exist and replace them.
+-    if (creation_locations.on_desktop)
+-      DeleteShortcutOnDesktop(shortcut_filename);
+-
+     if (creation_locations.applications_menu_location !=
+         APP_MENU_LOCATION_NONE) {
+       DeleteShortcutInApplicationsMenu(shortcut_filename, base::FilePath());
+@@ -353,14 +297,6 @@ bool CreateDesktopShortcut(const ShortcutInfo& shortcut_info,
+     return false;
+   }
+ 
+-  if (creation_locations.on_desktop) {
+-    std::string contents = shell_integration_linux::GetDesktopFileContents(
+-        chrome_exe_path, app_name, shortcut_info.url,
+-        shortcut_info.extension_id, shortcut_info.title, icon_name,
+-        shortcut_info.profile_path, "", "", false);
+-    success = CreateShortcutOnDesktop(shortcut_filename, contents);
+-  }
+-
+   if (creation_locations.applications_menu_location == APP_MENU_LOCATION_NONE) {
+     return success;
+   }
+@@ -458,14 +394,13 @@ bool DeleteDesktopShortcuts(const base::FilePath& profile_path,
+       GetAppShortcutFilename(profile_path, extension_id);
+   DCHECK(!shortcut_filename.empty());
+ 
+-  bool deleted_from_desktop = DeleteShortcutOnDesktop(shortcut_filename);
+   // Delete shortcuts from |kDirectoryFilename|.
+   // Note that it is possible that shortcuts were not created in the Chrome Apps
+   // directory. It doesn't matter: this will still delete the shortcut even if
+   // it isn't in the directory.
+   bool deleted_from_application_menu = DeleteShortcutInApplicationsMenu(
+       shortcut_filename, base::FilePath(kDirectoryFilename));
+-  return (deleted_from_desktop && deleted_from_application_menu);
++  return deleted_from_application_menu;
+ }
+ 
+ bool DeleteAllDesktopShortcuts(const base::FilePath& profile_path) {
+@@ -474,17 +409,6 @@ bool DeleteAllDesktopShortcuts(const base::FilePath& profile_path) {
+ 
+   std::unique_ptr<base::Environment> env(base::Environment::Create());
+   bool result = true;
+-  // Delete shortcuts from Desktop.
+-  base::FilePath desktop_path;
+-  if (base::PathService::Get(base::DIR_USER_DESKTOP, &desktop_path)) {
+-    std::vector<base::FilePath> shortcut_filenames_desktop =
+-        shell_integration_linux::GetExistingProfileShortcutFilenames(
+-            profile_path, desktop_path);
+-    for (const auto& shortcut : shortcut_filenames_desktop) {
+-      if (!DeleteShortcutOnDesktop(shortcut))
+-        result = false;
+-    }
+-  }
+ 
+   // Delete shortcuts from |kDirectoryFilename|.
+   base::FilePath applications_menu =
 -- 
 2.26.2
 

--- a/patches/0016-webhid-Properly-handle-lack-of-platform-support.patch
+++ b/patches/0016-webhid-Properly-handle-lack-of-platform-support.patch
@@ -1,7 +1,7 @@
-From bed141e5f919b4ff6928d89119c4ac9aa1f40f07 Mon Sep 17 00:00:00 2001
+From 24ee2d6fa6b311b127581f8e4ad54012c6e9d8aa Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <rymg19@gmail.com>
 Date: Wed, 11 Nov 2020 16:53:24 -0600
-Subject: [PATCH 16/21] [webhid] Properly handle lack of platform support
+Subject: [PATCH 16/22] [webhid] Properly handle lack of platform support
 
 This avoids crashes when the platform does not have an HID service,
 which can occur on builds without udev.

--- a/patches/0017-webusb-Properly-handle-lack-of-platform-support.patch
+++ b/patches/0017-webusb-Properly-handle-lack-of-platform-support.patch
@@ -1,7 +1,7 @@
-From 08b93f42b4eac65a8c9580e5e9ece522328fde15 Mon Sep 17 00:00:00 2001
+From 16f011ddfe5b6b137f49e7dc599cc631f25f5f58 Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <rymg19@gmail.com>
 Date: Wed, 11 Nov 2020 16:54:18 -0600
-Subject: [PATCH 17/21] [webusb] Properly handle lack of platform support
+Subject: [PATCH 17/22] [webusb] Properly handle lack of platform support
 
 This avoids crashes and infinite device service startup loops when the
 platform does not have a USB service, which can occur on builds without

--- a/patches/0018-Use-CHROME_WRAPPER-as-the-executable-on-restart.patch
+++ b/patches/0018-Use-CHROME_WRAPPER-as-the-executable-on-restart.patch
@@ -1,7 +1,7 @@
-From 9279e968504c6d40348c960fd7782d261d15f65a Mon Sep 17 00:00:00 2001
+From ca4a38da056b1e1b94db0d2c8063b362dafbb750 Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <rymg19@gmail.com>
 Date: Wed, 11 Nov 2020 17:13:38 -0600
-Subject: [PATCH 18/21] Use CHROME_WRAPPER as the executable on restart
+Subject: [PATCH 18/22] Use CHROME_WRAPPER as the executable on restart
 
 ---
  chrome/browser/first_run/upgrade_util_linux.cc | 7 ++++++-

--- a/patches/0019-Add-support-for-the-XDG-file-chooser-portal.patch
+++ b/patches/0019-Add-support-for-the-XDG-file-chooser-portal.patch
@@ -1,7 +1,7 @@
-From 67137a4314081aefefe4a60596eaae68f0e90949 Mon Sep 17 00:00:00 2001
+From 62a0b61c4e52a362982daea29c7cd4b4828e05e5 Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <rymg19@gmail.com>
 Date: Mon, 31 Aug 2020 15:26:52 -0500
-Subject: [PATCH 19/21] Add support for the XDG file chooser portal
+Subject: [PATCH 19/22] Add support for the XDG file chooser portal
 
 ---
  chrome/browser/about_flags.cc             |   7 +

--- a/patches/0020-Add-OpenURI-portal-support-for-opening-directories.patch
+++ b/patches/0020-Add-OpenURI-portal-support-for-opening-directories.patch
@@ -1,7 +1,7 @@
-From 189d03a017a216e2dfced95e29bfcd095532a542 Mon Sep 17 00:00:00 2001
+From 824472e8eb944750ff2d39e7f5745cab6daeb359 Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <rymg19@gmail.com>
 Date: Tue, 17 Nov 2020 22:35:26 -0600
-Subject: [PATCH 20/21] Add OpenURI portal support for opening directories
+Subject: [PATCH 20/22] Add OpenURI portal support for opening directories
 
 ---
  chrome/browser/platform_util_linux.cc | 80 +++++++++++++++++++++++----

--- a/patches/0021-Remove-references-to-enable-dse-memoryssa.patch
+++ b/patches/0021-Remove-references-to-enable-dse-memoryssa.patch
@@ -1,7 +1,7 @@
-From 9ef0c77804ebc29637d69d61767d7f8ad0c1ce8b Mon Sep 17 00:00:00 2001
+From 62f7d75195022970840ce4af6981414c581dbc4d Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <rymg19@gmail.com>
 Date: Tue, 17 Nov 2020 23:33:35 -0600
-Subject: [PATCH 21/21] Remove references to enable-dse-memoryssa
+Subject: [PATCH 21/22] Remove references to enable-dse-memoryssa
 
 This was a feature added in (or at least enabled by default in) LLVM 12,
 which is far newer than the freedesktop SDK's LLVM 10. Therefore, it

--- a/patches/0022-Enable-new-dtags-on-non-component-builds.patch
+++ b/patches/0022-Enable-new-dtags-on-non-component-builds.patch
@@ -1,0 +1,46 @@
+From 6f29fffce906db9ace522f6c84b540f80ea8b5d9 Mon Sep 17 00:00:00 2001
+From: Ryan Gonzalez <rymg19@gmail.com>
+Date: Thu, 19 Nov 2020 16:20:05 -0600
+Subject: [PATCH 22/22] Enable new-dtags on non-component builds
+
+---
+ build/config/gcc/BUILD.gn | 23 ++++++++++++++++-------
+ 1 file changed, 16 insertions(+), 7 deletions(-)
+
+diff --git a/build/config/gcc/BUILD.gn b/build/config/gcc/BUILD.gn
+index 154b259b5faea..e8be9ca824ca7 100644
+--- a/build/config/gcc/BUILD.gn
++++ b/build/config/gcc/BUILD.gn
+@@ -100,13 +100,22 @@ config("executable_config") {
+   }
+ 
+   if (!is_android && current_os != "aix") {
+-    ldflags += [
+-      # TODO(GYP): Do we need a check on the binutils version here?
+-      #
+-      # Newer binutils don't set DT_RPATH unless you disable "new" dtags
+-      # and the new DT_RUNPATH doesn't work without --no-as-needed flag.
+-      "-Wl,--disable-new-dtags",
+-    ]
++    if (is_component_build) {
++      ldflags += [
++        # TODO(GYP): Do we need a check on the binutils version here?
++        #
++        # Newer binutils don't set DT_RPATH unless you disable "new" dtags
++        # and the new DT_RUNPATH doesn't work without --no-as-needed flag.
++        "-Wl,--disable-new-dtags",
++      ]
++    } else {
++      # Using DT_RUNPATH breaks the component builds, because RUNPATH isn't used
++      # to look up transitive dependencies like RPATH is, but it's fine for
++      # primarily static builds.
++      ldflags += [
++        "-Wl,--enable-new-dtags"
++      ]
++    }
+   }
+ }
+ 
+-- 
+2.26.2
+


### PR DESCRIPTION
This does the following:

- Removes new-dtags from non-component builds:
  new-dtags will use DT_RUNPATH instead of DT_RPATH, which means that
  LD_LIBRARY_PATH will be given higher priority. This breaks standard
  component builds, since DT_RUNPATH isn't used to resolve transitive
  dependencies, but that doesn't matter for our static release builds.
  Closes #15.
- Updates the Chromium version history in the metainfo file:
  This had grown pretty grossly out of date. Closes #25.
- Tweaks the extension points (again).