### PR TITLE
Add support for respecting system proxy settings

### DIFF
--- a/org.chromium.Chromium.metainfo.xml
+++ b/org.chromium.Chromium.metainfo.xml
@@ -26,6 +26,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="87.0.4280.88-1" date="2020-12-17" />
     <release version="87.0.4280.88" date="2020-12-04" />
     <release version="87.0.4280.66" date="2020-11-18" />
     <release version="86.0.4240.198" date="2020-11-12" />

--- a/org.chromium.Chromium.yaml
+++ b/org.chromium.Chromium.yaml
@@ -258,6 +258,7 @@ modules:
           - patches/0020-Add-OpenURI-portal-support-for-opening-directories.patch
           - patches/0021-Remove-references-to-enable-dse-memoryssa.patch
           - patches/0022-Enable-new-dtags-on-non-component-builds.patch
+          - patches/0023-Add-support-for-respecting-system-proxy-settings-whe.patch
       - type: file
         path: org.chromium.Chromium.desktop
       - type: file

--- a/patches/0023-Add-support-for-respecting-system-proxy-settings-whe.patch
+++ b/patches/0023-Add-support-for-respecting-system-proxy-settings-whe.patch
@@ -1,0 +1,388 @@
+From 2fc65c6722cdd50accf044868de3a4614309c172 Mon Sep 17 00:00:00 2001
+From: Andre Moreira Magalhaes <andre.magalhaes@endlessos.org>
+Date: Thu, 17 Dec 2020 19:05:10 -0300
+Subject: [PATCH 23/23] Add support for respecting system proxy settings when
+ running on Linux/Flatpak
+
+Some general notes on implementation:
+- The implementation uses the same codepath used when
+  `--winhttp-proxy-resolver` is passed as param, which uses the
+  `net::ProxyResolver` interface to determine the proxy given an url:
+  - This is due to limitations in the portal APIs which don't allow
+    access to the system proxy settings, and with that no reliable
+    way to implement a proper ProxyConfigService when on flatpak
+  - Despite the name of the param, this flag is not Windows(tm)
+    specific and also used on Mac builds
+  - This param may be removed at some point in the future, see
+    https://bugs.chromium.org/p/chromium/issues/detail?id=644030 but
+    it should be replaced with
+    https://bugs.chromium.org/p/chromium/issues/detail?id=1032820,
+    which from the looks of it would not require too many changes
+    to the impl here
+  - To avoid having to pass this param, this codepath is enabled
+     automatically when detecting we are running on flatpak
+- This means that proxy resolution is done by invoking
+  `net::ProxyResolver::GetProxyForURL()` (instead of relying on the
+  internal chromium mechanism based on the proxy settings, set to
+  "mode=auto" in this case), which in turn invokes
+  `g_proxy_resolver_lookup` which uses the portal API via D-Bus
+  - To avoid having one D-Bus call per
+    `net::ProxyResolver::GetProxyForURL()`, this implements a (very)
+    simple cache that gets invalidated every 1min (same default
+    timeout used on chromium dns refresh)
+- Another issue is that the impl will invoke the portal even if
+  proxy is disabled in the system, also because of a limitation
+  in the portal API where there is no way to know whether the
+  proxy is disabled
+- We could skip using the portal on KDE, given the flatpak has
+  access to $HOME today (and the impl just reads .ini files),
+  but this impl uses the same codepath no matter the DE when running
+  on flatpak
+
+Closes https://github.com/flathub/org.chromium.Chromium/issues/36
+---
+ chrome/app/generated_resources.grd            |   6 +
+ .../net/system_network_context_manager.cc     |   9 +-
+ chrome/browser/ui/webui/about_ui.cc           |  14 +-
+ net/BUILD.gn                                  |   3 +
+ .../configured_proxy_resolution_service.cc    |   5 +-
+ .../proxy_config_service_linux.cc             |  10 +-
+ net/proxy_resolution/proxy_resolver_linux.cc  | 127 ++++++++++++++++++
+ net/proxy_resolution/proxy_resolver_linux.h   |  31 +++++
+ 8 files changed, 201 insertions(+), 4 deletions(-)
+ create mode 100644 net/proxy_resolution/proxy_resolver_linux.cc
+ create mode 100644 net/proxy_resolution/proxy_resolver_linux.h
+
+diff --git a/chrome/app/generated_resources.grd b/chrome/app/generated_resources.grd
+index eca8e40478142..c83ef84dcc7e6 100644
+--- a/chrome/app/generated_resources.grd
++++ b/chrome/app/generated_resources.grd
+@@ -9295,6 +9295,12 @@ Please help our engineers fix this problem. Tell us what happened right before y
+ 
+           &lt;p&gt;But you can still configure via the command line.  Please see &lt;code&gt;man <ph name="PRODUCT_BINARY_NAME">$2<ex>google-chrome</ex></ph>&lt;/code&gt; for more information on flags and environment variables.&lt;/p&gt;
+         </message>
++        <message name="IDS_ABOUT_LINUX_PROXY_CONFIG_FLATPAK_BODY" desc="HTML body of page shown on systems running with flatpak where system proxy configuration is unsupported.">
++          &lt;p&gt;The flatpak version of <ph name="PRODUCT_NAME">$1<ex>Google Chrome</ex></ph> does not support changing the system proxy settings. However, it does respect those settings.&lt;/p&gt;
++          &lt;p&gt;If you need to adjust the proxy settings, please do so through the configuration system of your desktop environment.&lt;/p&gt;
++
++          &lt;p&gt;You can also override your system proxy settings via the command line. Please see &lt;code&gt;man <ph name="PRODUCT_BINARY_NAME">$2<ex>google-chrome</ex></ph>&lt;/code&gt; for more information on flags and environment variables.&lt;/p&gt;
++        </message>
+       </if>
+ 
+       <message name="IDS_IMAGE_FILES" desc="The description of the image file extensions in the select file dialog.">
+diff --git a/chrome/browser/net/system_network_context_manager.cc b/chrome/browser/net/system_network_context_manager.cc
+index c53056f7a4ba5..b0d0d422912a9 100644
+--- a/chrome/browser/net/system_network_context_manager.cc
++++ b/chrome/browser/net/system_network_context_manager.cc
+@@ -80,6 +80,7 @@
+ #if defined(OS_LINUX) && !defined(OS_CHROMEOS)
+ #include "chrome/common/chrome_paths_internal.h"
+ #include "chrome/grit/chromium_strings.h"
++#include "sandbox/linux/services/flatpak_sandbox.h"
+ #include "ui/base/l10n/l10n_util.h"
+ #endif  // defined(OS_LINUX) && !defined(OS_CHROMEOS)
+ 
+@@ -579,7 +580,13 @@ void SystemNetworkContextManager::ConfigureDefaultNetworkContextParams(
+   // or if it does work, now.
+   // Should be possible now that a private isolate is used.
+   // http://crbug.com/474654
+-  if (!command_line.HasSwitch(switches::kWinHttpProxyResolver)) {
++  bool use_system_proxy_resolver = command_line.HasSwitch(switches::kWinHttpProxyResolver);
++#if defined(OS_LINUX)
++  bool use_flatpak_sandbox = (sandbox::FlatpakSandbox::GetInstance()->GetSandboxLevel() >
++                              sandbox::FlatpakSandbox::SandboxLevel::kNone);
++  use_system_proxy_resolver |= use_flatpak_sandbox;
++#endif
++  if (!use_system_proxy_resolver) {
+     if (command_line.HasSwitch(switches::kSingleProcess)) {
+       LOG(ERROR) << "Cannot use V8 Proxy resolver in single process mode.";
+     } else {
+diff --git a/chrome/browser/ui/webui/about_ui.cc b/chrome/browser/ui/webui/about_ui.cc
+index ba4753e68de1b..8cff42d24ea59 100644
+--- a/chrome/browser/ui/webui/about_ui.cc
++++ b/chrome/browser/ui/webui/about_ui.cc
+@@ -93,6 +93,10 @@
+ #include "third_party/cros_system_api/dbus/service_constants.h"
+ #endif
+ 
++#if defined(OS_LINUX)
++#include "sandbox/linux/services/flatpak_sandbox.h"
++#endif
++
+ using content::BrowserThread;
+ 
+ namespace {
+@@ -587,8 +591,16 @@ std::string AboutLinuxProxyConfig() {
+   data.append("<style>body { max-width: 70ex; padding: 2ex 5ex; }</style>");
+   AppendBody(&data);
+   base::FilePath binary = base::CommandLine::ForCurrentProcess()->GetProgram();
++
++  int id = IDS_ABOUT_LINUX_PROXY_CONFIG_BODY;
++#if defined(OS_LINUX)
++  bool use_flatpak_sandbox = (sandbox::FlatpakSandbox::GetInstance()->GetSandboxLevel() >
++                              sandbox::FlatpakSandbox::SandboxLevel::kNone);
++  if (use_flatpak_sandbox)
++    id = IDS_ABOUT_LINUX_PROXY_CONFIG_FLATPAK_BODY;
++#endif
+   data.append(
+-      l10n_util::GetStringFUTF8(IDS_ABOUT_LINUX_PROXY_CONFIG_BODY,
++      l10n_util::GetStringFUTF8(id,
+                                 l10n_util::GetStringUTF16(IDS_PRODUCT_NAME),
+                                 base::ASCIIToUTF16(binary.BaseName().value())));
+   AppendFooter(&data);
+diff --git a/net/BUILD.gn b/net/BUILD.gn
+index c399590e2b02d..77be307aec8b8 100644
+--- a/net/BUILD.gn
++++ b/net/BUILD.gn
+@@ -1248,6 +1248,8 @@ component("net") {
+         "base/network_change_notifier_linux.h",
+         "proxy_resolution/proxy_config_service_linux.cc",
+         "proxy_resolution/proxy_config_service_linux.h",
++        "proxy_resolution/proxy_resolver_linux.cc",
++        "proxy_resolution/proxy_resolver_linux.h",
+       ]
+     }
+ 
+@@ -1712,6 +1714,7 @@ source_set("net_deps") {
+ 
+     if (use_gio) {
+       public_configs += [ "//build/linux:gio_config" ]
++      public_deps += [ "//dbus" ]
+     }
+ 
+     if (is_android) {
+diff --git a/net/proxy_resolution/configured_proxy_resolution_service.cc b/net/proxy_resolution/configured_proxy_resolution_service.cc
+index 7a7ca7518ee05..3474b60dcc570 100644
+--- a/net/proxy_resolution/configured_proxy_resolution_service.cc
++++ b/net/proxy_resolution/configured_proxy_resolution_service.cc
+@@ -48,6 +48,7 @@
+ #include "net/proxy_resolution/proxy_resolver_mac.h"
+ #elif defined(OS_LINUX) && !defined(OS_CHROMEOS)
+ #include "net/proxy_resolution/proxy_config_service_linux.h"
++#include "net/proxy_resolution/proxy_resolver_linux.h"
+ #elif defined(OS_ANDROID)
+ #include "net/proxy_resolution/proxy_config_service_android.h"
+ #endif
+@@ -258,6 +259,8 @@ class ProxyResolverFactoryForSystem : public MultiThreadedProxyResolverFactory {
+     return std::make_unique<ProxyResolverFactoryWinHttp>();
+ #elif defined(OS_APPLE)
+     return std::make_unique<ProxyResolverFactoryMac>();
++#elif defined(OS_LINUX)
++    return std::make_unique<ProxyResolverFactoryLinux>();
+ #else
+     NOTREACHED();
+     return nullptr;
+@@ -265,7 +268,7 @@ class ProxyResolverFactoryForSystem : public MultiThreadedProxyResolverFactory {
+   }
+ 
+   static bool IsSupported() {
+-#if defined(OS_WIN) || defined(OS_APPLE)
++#if defined(OS_WIN) || defined(OS_APPLE) || defined(OS_LINUX)
+     return true;
+ #else
+     return false;
+diff --git a/net/proxy_resolution/proxy_config_service_linux.cc b/net/proxy_resolution/proxy_config_service_linux.cc
+index c11685ff4f221..cba0225d69512 100644
+--- a/net/proxy_resolution/proxy_config_service_linux.cc
++++ b/net/proxy_resolution/proxy_config_service_linux.cc
+@@ -31,6 +31,7 @@
+ #include "base/threading/thread_restrictions.h"
+ #include "base/timer/timer.h"
+ #include "net/base/proxy_server.h"
++#include "sandbox/linux/services/flatpak_sandbox.h"
+ 
+ #if defined(USE_GIO)
+ #include <gio/gio.h>
+@@ -1042,11 +1043,18 @@ ProxyConfigServiceLinux::Delegate::GetConfigFromSettings() {
+   ProxyConfig config;
+ 
+   std::string mode;
+-  if (!setting_getter_->GetString(SettingGetter::PROXY_MODE, &mode)) {
++  bool use_flatpak_sandbox = (sandbox::FlatpakSandbox::GetInstance()->GetSandboxLevel() >
++                              sandbox::FlatpakSandbox::SandboxLevel::kNone);
++
++  if (!use_flatpak_sandbox &&
++      !setting_getter_->GetString(SettingGetter::PROXY_MODE, &mode)) {
+     // We expect this to always be set, so if we don't see it then we probably
+     // have a gsettings problem, and so we don't have a valid proxy config.
+     return base::nullopt;
++  } else if (use_flatpak_sandbox) {
++    mode = "auto";
+   }
++
+   if (mode == "none") {
+     // Specifically specifies no proxy.
+     return ProxyConfigWithAnnotation(
+diff --git a/net/proxy_resolution/proxy_resolver_linux.cc b/net/proxy_resolution/proxy_resolver_linux.cc
+new file mode 100644
+index 0000000000000..c9ad62e6e09b3
+--- /dev/null
++++ b/net/proxy_resolution/proxy_resolver_linux.cc
+@@ -0,0 +1,127 @@
++// Copyright (c) 2020 Endless OS Foundation LLC
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "net/proxy_resolution/proxy_resolver_linux.h"
++
++#include "base/time/time.h"
++#include "base/timer/timer.h"
++#include "net/base/net_errors.h"
++#include "net/proxy_resolution/proxy_info.h"
++#include "net/proxy_resolution/proxy_resolver.h"
++#include "sandbox/linux/services/flatpak_sandbox.h"
++
++#if defined(USE_GIO)
++#include <gio/gio.h>
++#endif  // defined(USE_GIO)
++
++namespace net {
++
++namespace {
++
++#if defined(USE_GIO)
++// Same TTL used for DNS caches, see net/dns/host_resolver_manager.cc
++static const unsigned kCacheExpireSeconds = 60;
++
++class ProxyResolverLinuxImplPortal : public ProxyResolver {
++ public:
++  explicit ProxyResolverLinuxImplPortal();
++  ~ProxyResolverLinuxImplPortal() override;
++
++  // ProxyResolver methods:
++  int GetProxyForURL(const GURL& url,
++                     const NetworkIsolationKey& network_isolation_key,
++                     ProxyInfo* results,
++                     CompletionOnceCallback callback,
++                     std::unique_ptr<Request>* request,
++                     const NetLogWithSource& net_log) override;
++
++ private:
++  void InvalidateCache();
++
++  // Both InvalidateCache and GetProxyForURL run on the same thread,
++  // no need for explicit synchronization here
++  std::map<std::string, std::string> cache_;
++  base::RepeatingTimer cacheInvalidateTimer_;
++
++  GCancellable* cancellable_;
++};
++
++ProxyResolverLinuxImplPortal::ProxyResolverLinuxImplPortal()
++{
++  cancellable_ = g_cancellable_new();
++
++  cacheInvalidateTimer_.Start(FROM_HERE,
++      base::TimeDelta::FromSeconds(kCacheExpireSeconds),
++      this, &ProxyResolverLinuxImplPortal::InvalidateCache);
++}
++
++ProxyResolverLinuxImplPortal::~ProxyResolverLinuxImplPortal()
++{
++  g_cancellable_cancel(cancellable_);
++  g_clear_object(&cancellable_);
++  cacheInvalidateTimer_.Stop();
++}
++
++// Runs on the worker thread
++int ProxyResolverLinuxImplPortal::GetProxyForURL(
++    const GURL& query_url,
++    const NetworkIsolationKey& /* network_isolation_key */,
++    ProxyInfo* results,
++    CompletionOnceCallback /* callback */,
++    std::unique_ptr<Request>* /* request */,
++    const NetLogWithSource& /* net_log */) {
++  std::map<std::string, std::string>::const_iterator it =
++      cache_.find(query_url.spec());
++  if (it != cache_.end()) {
++    results->UseNamedProxy(it->second);
++    return OK;
++  }
++
++  GProxyResolver *resolver = g_proxy_resolver_get_default();
++  // TODO: support async resolution if 'request' is non-null - the current
++  // consumer is MultiThreadProxyResolver which always expects a sync
++  // resolver
++  // TODO: handle/warn on error
++  g_auto(GStrv) proxy_list = g_proxy_resolver_lookup(resolver,
++      query_url.spec().c_str(), cancellable_, NULL);
++  if (proxy_list) {
++    g_autofree gchar *proxy_list_str = g_strjoinv(";", proxy_list);
++    if (proxy_list_str && proxy_list_str[0] != '\0') {
++      cache_[query_url.spec()] = proxy_list_str;
++      results->UseNamedProxy(proxy_list_str);
++    }
++  }
++
++  return OK;
++}
++
++void ProxyResolverLinuxImplPortal::InvalidateCache()
++{
++  cache_.clear();
++}
++
++#endif // defined(USE_GIO)
++
++} // namespace
++
++ProxyResolverFactoryLinux::ProxyResolverFactoryLinux()
++    : ProxyResolverFactory(false /* expects_pac_bytes */) {
++}
++
++int ProxyResolverFactoryLinux::CreateProxyResolver(
++    const scoped_refptr<PacFileData>& pac_script,
++    std::unique_ptr<ProxyResolver>* resolver,
++    CompletionOnceCallback callback,
++    std::unique_ptr<Request>* request) {
++#if defined(USE_GIO)
++  if (sandbox::FlatpakSandbox::GetInstance()->GetSandboxLevel() >
++      sandbox::FlatpakSandbox::SandboxLevel::kNone) {
++    resolver->reset(new ProxyResolverLinuxImplPortal());
++    return OK;
++  }
++#endif
++  return ERR_NOT_IMPLEMENTED;
++}
++
++}  // namespace net
+diff --git a/net/proxy_resolution/proxy_resolver_linux.h b/net/proxy_resolution/proxy_resolver_linux.h
+new file mode 100644
+index 0000000000000..0a7a22aa44d59
+--- /dev/null
++++ b/net/proxy_resolution/proxy_resolver_linux.h
+@@ -0,0 +1,31 @@
++// Copyright (c) 2020 Endless OS Foundation LLC
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef NET_PROXY_RESOLUTION_PROXY_RESOLVER_LINUX_H_
++#define NET_PROXY_RESOLUTION_PROXY_RESOLVER_LINUX_H_
++
++#include "base/macros.h"
++#include "net/base/completion_once_callback.h"
++#include "net/base/net_export.h"
++#include "net/proxy_resolution/proxy_resolver_factory.h"
++#include "url/gurl.h"
++
++namespace net {
++
++class NET_EXPORT ProxyResolverFactoryLinux : public ProxyResolverFactory {
++ public:
++  ProxyResolverFactoryLinux();
++
++  int CreateProxyResolver(const scoped_refptr<PacFileData>& pac_script,
++                          std::unique_ptr<ProxyResolver>* resolver,
++                          CompletionOnceCallback callback,
++                          std::unique_ptr<Request>* request) override;
++
++ private:
++  DISALLOW_COPY_AND_ASSIGN(ProxyResolverFactoryLinux);
++};
++
++}  // namespace net
++
++#endif  // NET_PROXY_RESOLUTION_PROXY_RESOLVER_LINUX_H_
+-- 
+2.20.1
+


### PR DESCRIPTION
Ok, this is an attempt to implement support for respecting system proxy settings on the flatpak version.

Some general notes on implementation:
- The implementation uses the same codepath used when `--winhttp-proxy-resolver` is passed as param, which uses the `net::ProxyResolver` interface to determine the proxy given an url:
  - This is due to limitations in the portal APIs which don't allow access to the system proxy settings, and with that no reliable way to implement a proper ProxyConfigService when on flatpak
  - Despite the name of the param, this flag is not Windows(tm) specific and also used on Mac builds
  - This param may be removed at some point in the future, see https://bugs.chromium.org/p/chromium/issues/detail?id=644030 but it should be replaced with https://bugs.chromium.org/p/chromium/issues/detail?id=1032820, which from the looks of it would not require too many changes to the impl here
  - To avoid having to pass this param I've enabled this codepath automatically when detecting we are running on flatpak
- This means that proxy resolution is done by invoking `net::ProxyResolver::GetProxyForURL()` (instead of relying on the internal chromium mechanism based on the proxy settings, set to "mode=auto" in this case), which in turn invokes `g_proxy_resolver_lookup` which uses the portal API via D-Bus
  - To avoid having one D-Bus call per `net::ProxyResolver::GetProxyForURL()`, I've implemented a (very) simple cache that gets invalidated every 1min (same default timeout used on chromium dns refresh)
- Another issue is that the impl will invoke the portal even if proxy is disabled, also because of a limitation in the portal API where there is no way to know whether the proxy is disabled
- We could skip using the portal on KDE, given we have access to $HOME today (and the impl just reads .ini files), but I decided to go with the same impl when running on flatpak, but have no hard-preference here

On the bright side, it seems to work fine from my tests (could use some more tests though) and changes to the system settings (tested on GNOME/Endless) are reflected correctly (considering the cache invalidation timeout of 1min).

I am not really happy with the amount of D-Bus calls trigerred here tbh (esp. when proxy is disabled), but I can't think of another way to implement this with the current portal APIs - we could tweak the cache invalidation timeout but apart from that I don't think we could do much to improve.

See https://github.com/flatpak/xdg-desktop-portal/issues/554 for the portal API issues/limitations mentioned above.

Thoughts?

Closes https://github.com/flathub/org.chromium.Chromium/issues/36