### PR TITLE
Allow Chromium to access kerberos tickets from the host

### DIFF
--- a/org.chromium.Chromium.yaml
+++ b/org.chromium.Chromium.yaml
@@ -7,6 +7,7 @@ finish-args:
   - --require-version=1.8.2
   - --filesystem=home
   - --filesystem=xdg-run/pipewire-0
+  - --filesystem=/run/.heim_org.h5l.kcm-socket
   - --device=all
   - --env=GTK_PATH=/app/lib/gtkmodules
   - --env=LD_LIBRARY_PATH=/app/chromium/nonfree-codecs/lib


### PR DESCRIPTION
Backport of https://gitlab.gnome.org/GNOME/epiphany/-/commit/bba622a1b92c29cad65af3ca27f4d6be55a925c9 that is used in Epiphany.