### PR TITLE
desktop: Add 'chrome' and 'internet' keywords

### DIFF
--- a/org.chromium.Chromium.desktop
+++ b/org.chromium.Chromium.desktop
@@ -112,6 +112,7 @@ Terminal=false
 Icon=org.chromium.Chromium
 Type=Application
 Categories=Network;WebBrowser;
+Keywords=chrome;internet;
 MimeType=application/pdf;application/rdf+xml;application/rss+xml;application/xhtml+xml;application/xhtml_xml;application/xml;image/gif;image/jpeg;image/png;image/webp;text/html;text/xml;x-scheme-handler/ftp;x-scheme-handler/http;x-scheme-handler/https;
 Actions=new-window;new-private-window;
 # Used by Endless


### PR DESCRIPTION
@barthalion said:

> looking at some bare search stats, you may want to add "chrome" to the
> keywords in chromium's appdata file

I tried a few other obvious keywords and "internet" is the other one
which doesn't match.

(When the AppStream Collection Metadata is created, [keywords from `.desktop` files are extracted](https://www.freedesktop.org/software/appstream/docs/chap-CollectionData.html#tag-ct-keywords).)