### PR TITLE
Configure flatpak-external-data-checker to monitor stable releases only

### DIFF
--- a/org.chromium.Chromium.yaml
+++ b/org.chromium.Chromium.yaml
@@ -189,6 +189,7 @@ modules:
         x-checker-data:
           type: anitya
           project-id: 13344
+          stable-only: true
           url-template: https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$version.tar.xz
       - type: patch
         paths:


### PR DESCRIPTION
This is needed due to a recent change to the anitya checker:
  https://github.com/flathub/flatpak-external-data-checker/commit/12825bfd1de6669d32006d201ef1f827e43575ff