### PR TITLE
Use llvm11 extension for build

### DIFF
--- a/build-aux/build.sh
+++ b/build-aux/build.sh
@@ -4,4 +4,5 @@ ninja -C out/ReleaseFree -j$FLATPAK_BUILDER_N_JOBS libffmpeg.so
 
 . /usr/lib/sdk/node12/enable.sh
 . /usr/lib/sdk/openjdk11/enable.sh
+. /usr/lib/sdk/llvm11/enable.sh
 ninja -C out/Release -j$FLATPAK_BUILDER_N_JOBS chrome

--- a/org.chromium.Chromium.yaml
+++ b/org.chromium.Chromium.yaml
@@ -59,6 +59,7 @@ add-extensions:
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node12
   - org.freedesktop.Sdk.Extension.openjdk11
+  - org.freedesktop.Sdk.Extension.llvm11
 
 modules:
   - libsecret.json


### PR DESCRIPTION
This takes [latest llvm/clang toolchain](https://github.com/flathub/org.freedesktop.Sdk.Extension.llvm11) into use which also allows doing tests like [ASAN](https://github.com/flathub/org.chromium.Chromium/pull/6) without rebuilding llvm.