### PR TITLE
[WIP] Don't replace default CFLAGS during build

### DIFF
--- a/build-aux/build.sh
+++ b/build-aux/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ninja -C out/ReleaseFree -j$FLATPAK_BUILDER_N_JOBS libffmpeg.so
+CFLAGS= CXXFLAGS= ninja -C out/ReleaseFree -j$FLATPAK_BUILDER_N_JOBS libffmpeg.so
 
 . /usr/lib/sdk/node12/enable.sh
 . /usr/lib/sdk/openjdk11/enable.sh

--- a/org.chromium.Chromium.yaml
+++ b/org.chromium.Chromium.yaml
@@ -171,13 +171,13 @@ modules:
   - name: chromium
     buildsystem: simple
     build-options:
+      cflags: -Wno-unknown-warning-option -Wno-unknown-pragmas
+      cxxflags: -Wno-unknown-warning-option -Wno-unknown-pragmas
       env:
         CC: clang
         CXX: clang++
         AR: llvm-ar
         NM: llvm-nm
-        CFLAGS: -Wno-unknown-warning-option -Wno-unknown-pragmas
-        CXXFLAGS: -Wno-unknown-warning-option -Wno-unknown-pragmas
     build-commands:
       - ./bootstrap.sh
       - ./build.sh


### PR DESCRIPTION
Setting C/XXFLAGS env var explicitly replaces default set inherited from runtime which means losing all hardenings done there. Passing additional flags through dedicated f-b option will append them to default set.