### PR TITLE
Install swiftshader subdirectory

### DIFF
--- a/build-aux/install.sh
+++ b/build-aux/install.sh
@@ -4,7 +4,7 @@ mkdir -p /app/chromium
 
 pushd out/Release
 # Keep file names in sync with build_devel_flatpak.py
-for path in chrome icudtl.dat *.so *.pak *.bin *.png locales MEIPreload; do
+for path in chrome icudtl.dat *.so *.pak *.bin *.png locales MEIPreload swiftshader; do
     cp -rv $path /app/chromium
 done
 popd

--- a/utils/build_devel_flatpak.py
+++ b/utils/build_devel_flatpak.py
@@ -35,6 +35,7 @@ def rewrite_manifest_and_get_env(manifest_file, new_manifest_file, out_dir):
         '*.png',
         'locales',
         'MEIPreload',
+        'swiftshader',
     ]
 
     with open(manifest_file) as fp:


### PR DESCRIPTION
(Untested)

Spotted when trying to run Chromium with Ozone/Wayland and passing --use-gl=desktop. Chromium fails to load with:

```
Failed to load GLES library: /app/chromium/swiftshader/libGLESv2.so
```