### PR TITLE
Remove Google OAuth2 client ID & secret

### DIFF
--- a/build-aux/bootstrap.sh
+++ b/build-aux/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# DO NOT REUSE THE BELOW API KEYS; these are for Flathub only.
+# DO NOT REUSE THE BELOW API KEY; it is for Flathub only.
 # http://lists.debian.org/debian-legal/2013/11/msg00006.html
 tools/gn/bootstrap/bootstrap.py -v --no-clean --gn-gen-args='
     use_sysroot=false
@@ -15,8 +15,6 @@ tools/gn/bootstrap/bootstrap.py -v --no-clean --gn-gen-args='
     clang_use_chrome_plugins=false
     is_official_build=true
     google_api_key="AIzaSyAL6fqCZVFhA7K_qBvz9GO5Z-V1JBcPO0A"
-    google_default_client_id="62778694883-t4a8bf01lumav756cl6ujhhrqsqselq9.apps.googleusercontent.com"
-    google_default_client_secret="eeHsihEqYjhD2zuIROjerl_7"
     treat_warnings_as_errors=false
     proprietary_codecs=true
     ffmpeg_branding="Chrome"


### PR DESCRIPTION
As discussed in [this thread][0] and [this wiki page][1], these are used
to sign into Chromium for features like Chrome sync. Unfortunately,
these services are now only available to Google Chrome, not to
third-party builds of Chromium.  Developers can generate their own API
keys and add their Google account to a special mailing list, which will
allow them to sign in to Chromium for development and testing purposes,
but this only grants a very low quota.

Google recommends removing the default client ID & secret in third-party
builds. Do that here.

We keep the API key, which is used to access public APIs such as Safe
Browsing, and is not affected by this policy change.

Fixes #56, as best as is possible.

[0]: https://groups.google.com/a/chromium.org/g/chromium-packagers/c/SG6jnsP4pWM
[1]: https://www.chromium.org/developers/how-tos/api-keys
