### PR TITLE
Switch to OpenPrinting CUPS

### DIFF
--- a/org.chromium.Chromium.yaml
+++ b/org.chromium.Chromium.yaml
@@ -72,9 +72,13 @@ modules:
     cleanup:
       - /include
     sources:
-      - type: archive
-        url: https://github.com/apple/cups/releases/download/v2.3.3/cups-2.3.3-source.tar.gz
-        sha256: 261fd948bce8647b6d5cb2a1784f0c24cc52b5c4e827b71d726020bcc502f3ee
+      - type: git
+        url: https://github.com/OpenPrinting/cups.git
+        tag: v2.3.3op2
+        commit: 3b566f73587ffa8ad9690f2399efc4508b3a9016
+        x-checker-data:
+          type: git
+          tag-pattern: "^v([\\d.]+)"
 
   - name: gtk-cups-backend
     buildsystem: meson


### PR DESCRIPTION
Closes https://github.com/flathub/org.chromium.Chromium/issues/115

I used an older version of OpenPrinting's CUPS for testing, and I got it working:

```
 Has a new version:
  URL:       https://github.com/OpenPrinting/cups.git
  Commit:    3b566f73587ffa8ad9690f2399efc4508b3a9016
  Tag:       v2.3.3op2
  Branch:    None
  Version:   2.3.3
  Timestamp: None

```