### PR TITLE
Re-enable XDG file chooser portal

### DIFF
--- a/patches/0018-Add-support-for-the-XDG-file-chooser-portal.patch
+++ b/patches/0018-Add-support-for-the-XDG-file-chooser-portal.patch
@@ -91,7 +91,7 @@ index 29a222be4493a..0e7e312b8eee1 100644
 +#if defined(OS_LINUX)
 +// Enables use of the XDG file chooser portal for file selection.
 +const base::Feature kXdgFileChooserPortal{"XdgFileChooserPortal",
-+                                          base::FEATURE_DISABLED_BY_DEFAULT};
++                                          base::FEATURE_ENABLED_BY_DEFAULT};
 +#endif  // defined(OS_LINUX)
 +
 +#if defined(OS_MACOS)


### PR DESCRIPTION
Reverses part of cba74b8f9f246cc144231e06f4266a1b05d79757, since https://github.com/flatpak/xdg-desktop-portal/issues/545 is now fixed.

Fixes #33 

The freedesktop runtime appears to be on a [git snapshot of XDG desktop portal 1.8.1](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/master/elements/components/xdg-desktop-portal-base.bst), so this should work.