### PR TITLE
Enable PipeWire capturer by default

### DIFF
--- a/chromium.sh
+++ b/chromium.sh
@@ -40,6 +40,9 @@ fi
 # Merge the flags.
 if [[ -f "$XDG_CONFIG_HOME/chromium-flags.conf" ]]; then
   IFS=$'\n'
+  # Append non-default PipeWire flag for Wayland screen sharing 
+  echo "--enable-features=WebRTCPipeWireCapturer" >> "$XDG_CONFIG_HOME/chromium-flags.conf"
+
   flags=($(grep -v '^#' "$XDG_CONFIG_HOME/chromium-flags.conf"))
   unset IFS
 


### PR DESCRIPTION
Should only improve Wayland experience and not regress X11.
See https://github.com/flathub/org.chromium.Chromium/issues/121

If there's a cleaner/better way of doing this I can try and do so.