### PR TITLE
Remove x-scheme-handler/ftp from MimeTypes

### DIFF
--- a/org.chromium.Chromium.desktop
+++ b/org.chromium.Chromium.desktop
@@ -113,7 +113,7 @@ Icon=org.chromium.Chromium
 Type=Application
 Categories=Network;WebBrowser;
 Keywords=chrome;internet;
-MimeType=application/pdf;application/rdf+xml;application/rss+xml;application/xhtml+xml;application/xhtml_xml;application/xml;image/gif;image/jpeg;image/png;image/webp;text/html;text/xml;x-scheme-handler/ftp;x-scheme-handler/http;x-scheme-handler/https;
+MimeType=application/pdf;application/rdf+xml;application/rss+xml;application/xhtml+xml;application/xhtml_xml;application/xml;image/gif;image/jpeg;image/png;image/webp;text/html;text/xml;x-scheme-handler/http;x-scheme-handler/https;
 Actions=new-window;new-private-window;
 # Used by Endless
 X-Flatpak-RenamedFrom=chromium-browser.desktop;


### PR DESCRIPTION
Chromium 91 removed support for FTP.

This line is now identical to that from
https://chromium.googlesource.com/chromium/src/+/main/chrome/installer/linux/common/desktop.template.

Fixes #153
