### PR TITLE
[Fix #171] Inhibit screensaver when media is playing

### DIFF
--- a/org.chromium.Chromium.yaml
+++ b/org.chromium.Chromium.yaml
@@ -21,6 +21,7 @@ finish-args:
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=org.freedesktop.FileManager1
   - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.freedesktop.ScreenSaver
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.kde.kwalletd5
   - --talk-name=org.gnome.SessionManager


### PR DESCRIPTION
This fixes #171

By exposing DBus `org.freedesktop.ScreenSaver`, screen locking and sleep are properly inhibited when media is playing in Chromium.

How to test: 
- Launch the test build:
- Play media (such as a YouTube video) in Chromium, and see if computer turns off the screen, starts screensaver, or automatically suspends.

Reference: https://github.com/flathub/us.zoom.Zoom/issues/58
Edit: update "how to test"