### PR TITLE
Fix crash in PipeWire code when re-negotiating stream parameters

### DIFF
--- a/patches/all.json
+++ b/patches/all.json
@@ -17,6 +17,7 @@
       "patches/chromium/Clang-build-script-Allow-passing-a-prebuilt-Clang-for-boos.patch",
       "patches/chromium/Clang-build-script-Disable-hwasan.patch",
       "patches/chromium/clang-build-script-Support-disabling-the-bundled-libxml2.patch",
+      "patches/chromium/Webrtc-add-cfi-icall-to-avoid-crash-in-pipewire-functions.patch",
       "patches/ffmpeg/Enable-support-for-libfdk-aac-and-OpenH264.patch",
       "patches/ffmpeg/ffmpeg-Handle-transient-decode-errors-arising-from-libfdk-.patch",
       "patches/ffmpeg/Update-build-configuration.patch"

--- a/patches/chromium/Webrtc-add-cfi-icall-to-avoid-crash-in-pipewire-functions.patch
+++ b/patches/chromium/Webrtc-add-cfi-icall-to-avoid-crash-in-pipewire-functions.patch
@@ -1,0 +1,23 @@
+From 5f2d09cc2338eb75e014badfc037532c561c7d6d Mon Sep 17 00:00:00 2001
+From: Jan Grulich <grulja@gmail.com>
+Date: Thu, 5 May 2022 14:50:34 +0200
+Subject: Add CFI-ICALL to avoid crash in PipeWire functions
+
+We already use RTC_NO_SANITIZE("cfi-icall") for most of the code and
+it looks this one can be triggered recently with pw_loop_signal_event()
+call.
+
+Bug: webrtc:13659
+
+diff --git a/third_party/webrtc/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc b/third_party/webrtc/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
+index 9e81df4..2b0eb14 100644
+--- a/third_party/webrtc/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
++++ b/third_party/webrtc/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
+@@ -638,6 +638,7 @@ DesktopVector SharedScreenCastStreamPrivate::CaptureCursorPosition() {
+   return mouse_cursor_position_;
+ }
+ 
++RTC_NO_SANITIZE("cfi-icall")
+ void SharedScreenCastStreamPrivate::ProcessBuffer(pw_buffer* buffer) {
+   spa_buffer* spa_buffer = buffer->buffer;
+   ScopedBuf map;

--- a/patches/chromium/_sources.json
+++ b/patches/chromium/_sources.json
@@ -16,7 +16,8 @@
       "patches/chromium/Add-support-for-respecting-system-proxy-settings-when-runn.patch",
       "patches/chromium/Clang-build-script-Allow-passing-a-prebuilt-Clang-for-boos.patch",
       "patches/chromium/Clang-build-script-Disable-hwasan.patch",
-      "patches/chromium/clang-build-script-Support-disabling-the-bundled-libxml2.patch"
+      "patches/chromium/clang-build-script-Support-disabling-the-bundled-libxml2.patch",
+      "patches/chromium/Webrtc-add-cfi-icall-to-avoid-crash-in-pipewire-functions.patch"
     ]
   }
 ]


### PR DESCRIPTION
This should fix crash in https://github.com/emersion/xdg-desktop-portal-wlr/issues/205.

Upstream change is here: https://webrtc-review.googlesource.com/c/src/+/261300