### PR TITLE
Bump PipeWire version to 0.3.40

### DIFF
--- a/org.chromium.Chromium.yaml
+++ b/org.chromium.Chromium.yaml
@@ -66,6 +66,38 @@ sdk-extensions:
 modules:
   - libsecret.json
 
+  - name: pipewire
+    buildsystem: meson
+    config-opts:
+      - -Daudiotestsrc=disabled
+      - -Droc=disabled
+      - -Dvideotestsrc=disabled
+      - -Dvolume=disabled
+      - -Dvulkan=disabled
+      - -Ddocs=disabled
+      - -Dman=disabled
+      - -Dbluez5-codec-ldac=disabled
+      - -Dbluez5-codec-aptx=disabled
+      - -Dlibcamera=disabled
+      - -Dudevrulesdir=/app/lib/udev/rules.d/
+      - -Dsession-managers=[]
+      - -Dtests=disabled
+      - -Dexamples=disabled
+      - -Dpw-cat=disabled
+    cleanup:
+      - /include
+      - /bin
+    sources:
+      - type: git
+        url: https://github.com/pipewire/pipewire.git
+        tag: 0.3.40
+        commit: 7afd80052b7c49754a13c9ab49c368f95b60e0a7
+        x-checker-data:
+          type: anitya
+          project-id: 57357
+          stable-only: true
+          tag-template: $version
+
   - name: gtk-cups-backend
     buildsystem: meson
     make-args: [modules/printbackends/libprintbackend-cups.so]


### PR DESCRIPTION
To use the full potential of webrtc screencast we need to build against PipeWire 0.3.40. Until the next Runtime is released we can ship our own version of PipeWire. OBS does the same.