### PR TITLE
Update to runtime 22.08

### DIFF
--- a/org.chromium.Chromium.yaml
+++ b/org.chromium.Chromium.yaml
@@ -1,6 +1,6 @@
 app-id: org.chromium.Chromium
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 command: chromium
 finish-args:
@@ -59,7 +59,7 @@ add-extensions:
     autodelete: true
 
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.llvm13
+  - org.freedesktop.Sdk.Extension.llvm14
   - org.freedesktop.Sdk.Extension.node16
   - org.freedesktop.Sdk.Extension.openjdk11
 


### PR DESCRIPTION
22.08 brings a newer PipeWire version and might make #229  obsolete.