### PR TITLE
desktop: Add "google" keyword

### DIFF
--- a/org.chromium.Chromium.desktop
+++ b/org.chromium.Chromium.desktop
@@ -112,7 +112,7 @@ Terminal=false
 Icon=org.chromium.Chromium
 Type=Application
 Categories=Network;WebBrowser;
-Keywords=chrome;internet;
+Keywords=chrome;internet;google;
 MimeType=application/pdf;application/rdf+xml;application/rss+xml;application/xhtml+xml;application/xhtml_xml;application/xml;image/gif;image/jpeg;image/png;image/webp;text/html;text/xml;x-scheme-handler/http;x-scheme-handler/https;
 Actions=new-window;new-private-window;
 # Used by Endless


### PR DESCRIPTION
I'm watching a usability testing session. The user is struggling to find a web browser, which they refer to as "google". The computer has Chromium & Firefox installed, but not Chrome. So they cannot find the browser, and are trying to install a third one.

Chrome (stable and dev) show up in the search in Software, as does ungoogled-chromium. But this app doesn't mention the word "google" in its desktop file or metainfo, despite being more googly than ungoogled-chromium.

Add "google" as a keyword.