### PR TITLE
Change socket=x11 to socket=fallback-x11

### DIFF
--- a/org.chromium.Chromium.yaml
+++ b/org.chromium.Chromium.yaml
@@ -16,7 +16,7 @@ finish-args:
   - --share=network
   - --socket=cups
   - --socket=pulseaudio
-  - --socket=x11
+  - --socket=fallback-x11
   - --socket=wayland
   - --system-talk-name=org.freedesktop.Avahi
   - --system-talk-name=org.freedesktop.UPower


### PR DESCRIPTION
Allows systems with wayland available to enable only the wayland socket, and possibly avoid showing a "This app uses a legacy window system" warning.