### PR TITLE
allow Widevine on all architectures if present

### DIFF
--- a/patches/chromium/Import-chromium-71.0.3578.98-widevine-r3.patch.patch
+++ b/patches/chromium/Import-chromium-71.0.3578.98-widevine-r3.patch.patch
@@ -6,7 +6,8 @@ Subject: [PATCH] Import chromium-71.0.3578.98-widevine-r3.patch
 Taken from the Fedora 33 repositories.
 ---
  third_party/widevine/cdm/widevine_cdm_version.h | 2 ++
- 1 file changed, 2 insertions(+)
+ third_party/widevine/cdm/widevine.gni | 2 +-
+ 2 files changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/third_party/widevine/cdm/widevine_cdm_version.h b/third_party/widevine/cdm/widevine_cdm_version.h
 index db80700b6c1b2..370bb3c9724ec 100644
@@ -19,6 +20,17 @@ index db80700b6c1b2..370bb3c9724ec 100644
 +#define WIDEVINE_CDM_VERSION_STRING "unknown"
 +
  #endif  // WIDEVINE_CDM_VERSION_H_
+--- a/third_party/widevine/cdm/widevine.gni
++++ b/third_party/widevine/cdm/widevine.gni
+@@ -26,7 +26,7 @@
+ library_widevine_cdm_available =
+     (is_chromeos &&
+      (target_cpu == "x64" || target_cpu == "arm" || target_cpu == "arm64")) ||
+-    (target_os == "linux" && target_cpu == "x64") ||
++    (target_os == "linux") ||
+     (target_os == "mac" && (target_cpu == "x64" || target_cpu == "arm64")) ||
+     (target_os == "win" &&
+      (target_cpu == "x86" || target_cpu == "x64" || target_cpu == "arm64"))
 -- 
 2.41.0
 


### PR DESCRIPTION
refer to https://bugs.launchpad.net/ubuntu/bionic/+source/chromium-browser/+bug/2008433

Feel free to add yourself if it easier to maintain @refi64 
This will allow the use of widevine on all architectures if it is found, not just x64.
This was added to all Ubuntu chromium (bionic and snap) back in April.