### PR TITLE
Draft: Update Freedesktop SDK to 23.08 and Chromium base app to 23.08

### DIFF
--- a/org.chromium.Chromium.yaml
+++ b/org.chromium.Chromium.yaml
@@ -1,9 +1,9 @@
 app-id: org.chromium.Chromium
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 base: org.chromium.Chromium.BaseApp
-base-version: '22.08'
+base-version: '23.08'
 command: chromium
 finish-args:
   - --require-version=1.8.2


### PR DESCRIPTION
Depends on https://github.com/flathub/org.chromium.Chromium.BaseApp/pull/31 