### PR TITLE
Make vulkan driver visible to chrome(ium)

### DIFF
--- a/chromium.sh
+++ b/chromium.sh
@@ -32,4 +32,5 @@ fi
 unlink_profiles
 
 export LIBGL_DRIVERS_PATH=/usr/lib/$(uname -m)-linux-gnu/GL/lib/dri
+export VK_DRIVER_FILES=/usr/lib/$(uname -m)-linux-gnu/GL/vulkan/icd.d
 exec cobalt "$@"


### PR DESCRIPTION
I was trying to play with WebGPU in chromium and noticed that anything vulkan was not working. Thankfully, I stumbled upon this comment https://github.com/flatpak/flatpak/issues/5131#issuecomment-1947245971

TL;DR chrome(ium) vendors libvulkan, so it does not contains the patch that search the correct path for drivers, so this patch set the `VK_DRIVER_FILES` variable.

I think this should also be applied to the other chromium-based browser on flathub, so far I tested chromium and ungoogled-chromium.