### PR TITLE
fix access to kwallet on KDE Plasma6, fix #391

### DIFF
--- a/org.chromium.Chromium.yaml
+++ b/org.chromium.Chromium.yaml
@@ -26,6 +26,7 @@ finish-args:
   - --talk-name=org.freedesktop.ScreenSaver
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.kde.kwalletd5
+  - --talk-name=org.kde.kwalletd6
   - --talk-name=org.gnome.SessionManager
   - --own-name=org.mpris.MediaPlayer2.chromium.*
 


### PR DESCRIPTION
After my upgrade to Fedora 40 with KDE Plasma 6, chromium seem to have lost access to kwallet, even tho `org.freedesktop.secrets` session buss name should still allow it. 

Adding `org.kde.kwalletd6` seem to fix the problem.

Fixes #391