### PR TITLE
Add talk permissions to non-freedesktop dbus screensaver apis

### DIFF
--- a/org.chromium.Chromium.yaml
+++ b/org.chromium.Chromium.yaml
@@ -28,6 +28,10 @@ finish-args:
   - --talk-name=org.kde.kwalletd5
   - --talk-name=org.kde.kwalletd6
   - --talk-name=org.gnome.SessionManager
+  - --talk-name=org.gnome.ScreenSaver
+  - --talk-name=org.cinnamon.ScreenSaver
+  - --talk-name=org.mate.ScreenSaver
+  - --talk-name=org.xfce.ScreenSaver
   - --own-name=org.mpris.MediaPlayer2.chromium.*
 
 add-extensions:


### PR DESCRIPTION
Had a user reporting locking not working in the Bitwarden browser extension on the Flatpak version of Brave. Chromium talks to more than just the freedesktop screensaver dbus interface (cf. https://github.com/chromium/chromium/blob/140ebdb86130d4a1bc3c5b08448897ea5c5bda56/ui/base/idle/idle_linux.cc#L44-L55) . Since the chromium (and google-chrome) flatpak manifest has the same permissions regarding screensaver/lock dbus access, it causes the same issue as for Brave. This PR adds permission for the missing screensaver dbus apis. 