### PR TITLE
Update Freedesktop runtime to version 24.08

### DIFF
--- a/build-aux/bootstrap.sh
+++ b/build-aux/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 # Needed to build GN itself.
-. /usr/lib/sdk/llvm17/enable.sh
+. /usr/lib/sdk/llvm18/enable.sh
 
 # GN will use these variables to configure its own build, but they introduce
 # compat issues w/ Clang and aren't used by Chromium itself anyway, so just
@@ -17,8 +17,8 @@ if [[ -d third_party/llvm-build/Release+Asserts/bin ]]; then
 else
   python3 tools/clang/scripts/build.py --disable-asserts \
       --skip-checkout --use-system-cmake --use-system-libxml \
-      --host-cc=/usr/lib/sdk/llvm17/bin/clang \
-      --host-cxx=/usr/lib/sdk/llvm17/bin/clang++ \
+      --host-cc=/usr/lib/sdk/llvm18/bin/clang \
+      --host-cxx=/usr/lib/sdk/llvm18/bin/clang++ \
       --target-triple=$(clang -dumpmachine) \
       --without-android --without-fuchsia --without-zstd \
       --with-ml-inliner-model=

--- a/build-aux/build.sh
+++ b/build-aux/build.sh
@@ -8,7 +8,7 @@ ln_overwrite_all() {
 # Link our verisons of Node and OpenJDK into Chromium so the build scripts will
 # use them. For OpenJDK especially, this is a workaround for:
 # https://bugs.chromium.org/p/chromium/issues/detail?id=1192875
-ln_overwrite_all /usr/lib/sdk/node18 third_party/node/linux/node-linux-x64
+ln_overwrite_all /usr/lib/sdk/node20 third_party/node/linux/node-linux-x64
 ln_overwrite_all /usr/lib/sdk/openjdk21 third_party/jdk/current
 
 ninja -C out/ReleaseFree -j$FLATPAK_BUILDER_N_JOBS libffmpeg.so

--- a/org.chromium.Chromium.yaml
+++ b/org.chromium.Chromium.yaml
@@ -1,9 +1,9 @@
 app-id: org.chromium.Chromium
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 base: org.chromium.Chromium.BaseApp
-base-version: '23.08'
+base-version: '24.08'
 command: chromium
 finish-args:
   - --require-version=1.8.2
@@ -62,8 +62,8 @@ add-extensions:
     autodelete: true
 
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.llvm17
-  - org.freedesktop.Sdk.Extension.node18
+  - org.freedesktop.Sdk.Extension.llvm18
+  - org.freedesktop.Sdk.Extension.node20
   - org.freedesktop.Sdk.Extension.openjdk21
 
 modules:


### PR DESCRIPTION
This change was already done on Ungoogled Chromium a week ago: https://github.com/flathub/io.github.ungoogled_software.ungoogled_chromium/pull/57

It doesn't appear to have caused any issues I could spot and no new issues were made during this time. As it seems to be ready, make this change in Chromium as well.