### PR TITLE
Don't use the proxy portal by default

### DIFF
--- a/patches/chromium/Add-support-for-respecting-system-proxy-settings-when-runn.patch
+++ b/patches/chromium/Add-support-for-respecting-system-proxy-settings-when-runn.patch
@@ -1,4 +1,4 @@
-From 8eb17b876489bc1809ac902d0e75ebd2cea72e9f Mon Sep 17 00:00:00 2001
+From 7b554fb9aae32b623de48336e3cc564507cae492 Mon Sep 17 00:00:00 2001
 From: Andre Moreira Magalhaes <andre.magalhaes@endlessos.org>
 Date: Thu, 17 Dec 2020 19:05:10 -0300
 Subject: [PATCH] Add support for respecting system proxy settings when running
@@ -42,19 +42,19 @@ Some general notes on implementation:
 Closes https://github.com/flathub/org.chromium.Chromium/issues/36
 ---
  chrome/app/generated_resources.grd            |   6 +
- .../net/system_network_context_manager.cc     |  12 +-
+ .../net/system_network_context_manager.cc     |  18 ++-
  chrome/browser/ui/webui/about/about_ui.cc     |  14 +-
  net/BUILD.gn                                  |   3 +
  .../configured_proxy_resolution_service.cc    |   6 +-
  .../proxy_config_service_linux.cc             |  10 +-
  net/proxy_resolution/proxy_resolver_linux.cc  | 123 ++++++++++++++++++
  net/proxy_resolution/proxy_resolver_linux.h   |  29 +++++
- 8 files changed, 199 insertions(+), 4 deletions(-)
+ 8 files changed, 205 insertions(+), 4 deletions(-)
  create mode 100644 net/proxy_resolution/proxy_resolver_linux.cc
  create mode 100644 net/proxy_resolution/proxy_resolver_linux.h
 
 diff --git a/chrome/app/generated_resources.grd b/chrome/app/generated_resources.grd
-index 33c0b42d826b5..e051e70d0f4d7 100644
+index 33c0b42d826b5..09c0776864f0b 100644
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
 @@ -16435,6 +16435,12 @@ Please help our engineers fix this problem. Tell us what happened right before y
@@ -62,7 +62,7 @@ index 33c0b42d826b5..e051e70d0f4d7 100644
            &lt;p&gt;But you can still configure via the command line.  Please see &lt;code&gt;man <ph name="PRODUCT_BINARY_NAME">$2<ex>google-chrome</ex></ph>&lt;/code&gt; for more information on flags and environment variables.&lt;/p&gt;
          </message>
 +        <message name="IDS_ABOUT_LINUX_PROXY_CONFIG_FLATPAK_BODY" desc="HTML body of page shown on systems running with flatpak where system proxy configuration is unsupported.">
-+          &lt;p&gt;The flatpak version of <ph name="PRODUCT_NAME">$1<ex>Google Chrome</ex></ph> does not support changing the system proxy settings. However, it does respect those settings.&lt;/p&gt;
++          &lt;p&gt;The flatpak version of <ph name="PRODUCT_NAME">$1<ex>Google Chrome</ex></ph> does not support changing the system proxy settings. However, it does respect those settings when run with --use-system-proxy-resolver.&lt;/p&gt;
 +          &lt;p&gt;If you need to adjust the proxy settings, please do so through the configuration system of your desktop environment.&lt;/p&gt;
 +
 +          &lt;p&gt;You can also override your system proxy settings via the command line. Please see &lt;code&gt;man <ph name="PRODUCT_BINARY_NAME">$2<ex>google-chrome</ex></ph>&lt;/code&gt; for more information on flags and environment variables.&lt;/p&gt;
@@ -71,7 +71,7 @@ index 33c0b42d826b5..e051e70d0f4d7 100644
  
        <message name="IDS_IMAGE_FILES" desc="The description of the image file extensions in the select file dialog.">
 diff --git a/chrome/browser/net/system_network_context_manager.cc b/chrome/browser/net/system_network_context_manager.cc
-index d69e5334e67a4..1e598a0d0b59f 100644
+index d69e5334e67a4..1b264db869a39 100644
 --- a/chrome/browser/net/system_network_context_manager.cc
 +++ b/chrome/browser/net/system_network_context_manager.cc
 @@ -101,6 +101,10 @@
@@ -85,16 +85,22 @@ index d69e5334e67a4..1e598a0d0b59f 100644
  #if BUILDFLAG(IS_WIN)
  #include "chrome/browser/net/chrome_mojo_proxy_resolver_win.h"
  #endif  // BUILDFLAG(IS_WIN)
-@@ -977,7 +981,13 @@ void SystemNetworkContextManager::ConfigureDefaultNetworkContextParams(
+@@ -977,7 +981,19 @@ void SystemNetworkContextManager::ConfigureDefaultNetworkContextParams(
    // or if it does work, now.
    // Should be possible now that a private isolate is used.
    // http://crbug.com/41166927
 -  if (!command_line.HasSwitch(switches::kWinHttpProxyResolver)) {
-+  bool use_system_proxy_resolver = command_line.HasSwitch(switches::kWinHttpProxyResolver);
++  bool use_system_proxy_resolver =
++      command_line.HasSwitch(switches::kWinHttpProxyResolver);
 +#if defined(OS_LINUX)
-+  bool use_flatpak_sandbox = (sandbox::FlatpakSandbox::GetInstance()->GetSandboxLevel() >
-+                              sandbox::FlatpakSandbox::SandboxLevel::kNone);
-+  use_system_proxy_resolver |= use_flatpak_sandbox;
++  if (!use_system_proxy_resolver) {
++    bool use_flatpak_sandbox =
++        (sandbox::FlatpakSandbox::GetInstance()->GetSandboxLevel() >
++         sandbox::FlatpakSandbox::SandboxLevel::kNone);
++    use_system_proxy_resolver =
++        use_flatpak_sandbox &&
++        command_line.HasSwitch(switches::kUseSystemProxyResolver);
++  }
 +#endif
 +  if (!use_system_proxy_resolver) {
      if (command_line.HasSwitch(switches::kSingleProcess)) {

--- a/patches/chromium/Clang-build-script-Disable-hwasan.patch
+++ b/patches/chromium/Clang-build-script-Disable-hwasan.patch
@@ -1,4 +1,4 @@
-From 6245c89bbb9c6063a4904bbf1719fb8d8991e75b Mon Sep 17 00:00:00 2001
+From 0b9a4a483b32066fa47350204346484a136c324a Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <rymg19@gmail.com>
 Date: Thu, 30 Sep 2021 11:27:43 -0500
 Subject: [PATCH] Clang build script: Disable hwasan

--- a/patches/chromium/Clang-build-script-Don-t-build-against-the-sysroot.patch
+++ b/patches/chromium/Clang-build-script-Don-t-build-against-the-sysroot.patch
@@ -1,4 +1,4 @@
-From 000a597ba43a4cf9542e038196b2c0d32707272e Mon Sep 17 00:00:00 2001
+From 128964866a61d5237ac36f6699e096a40fd8b037 Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <rymg19@gmail.com>
 Date: Wed, 31 Aug 2022 10:09:01 -0500
 Subject: [PATCH] Clang build script: Don't build against the sysroot

--- a/patches/chromium/Clang-build-script-add-support-for-building-a-subset-of-ta.patch
+++ b/patches/chromium/Clang-build-script-add-support-for-building-a-subset-of-ta.patch
@@ -1,4 +1,4 @@
-From c3c4bdbf5a561c8968ec7f90ff593e8369bf672b Mon Sep 17 00:00:00 2001
+From 504040704a0a07fe52009f9223ec523c6bec2c5a Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <git@refi64.dev>
 Date: Wed, 13 Sep 2023 09:31:07 -0500
 Subject: [PATCH] Clang build script: add support for building a subset of

--- a/patches/chromium/Only-check-the-Node-major-version-number.patch
+++ b/patches/chromium/Only-check-the-Node-major-version-number.patch
@@ -1,4 +1,4 @@
-From 5171a0dfa425b1e697e5f6df0847a04b407dbcad Mon Sep 17 00:00:00 2001
+From c1c28c9dfee4ca274310f6c2bce069d9e0f2bd44 Mon Sep 17 00:00:00 2001
 From: "re:fi.64" <hello@refi64.dev>
 Date: Wed, 30 Apr 2025 10:03:07 -0500
 Subject: [PATCH] Only check the Node major version number

--- a/patches/chromium/build-Always-set-rustc_nightly_capability.patch
+++ b/patches/chromium/build-Always-set-rustc_nightly_capability.patch
@@ -1,4 +1,4 @@
-From a8be91ef453f7abd8198263add0301f270e33e5f Mon Sep 17 00:00:00 2001
+From 360ff574f40be7f703debb02cbc8b3be4b6079aa Mon Sep 17 00:00:00 2001
 From: "re:fi.64" <hello@refi64.dev>
 Date: Fri, 16 Jan 2026 15:49:49 -0600
 Subject: [PATCH] build: Always set rustc_nightly_capability

--- a/patches/chromium/build-Only-check-rustc_revision-when-using-Chromium-s-Rust.patch
+++ b/patches/chromium/build-Only-check-rustc_revision-when-using-Chromium-s-Rust.patch
@@ -1,4 +1,4 @@
-From 271a54c0ceb895750f2b8f3c6ecd26c83aef862c Mon Sep 17 00:00:00 2001
+From a18897df8045d4dd92833f7e3a64d666fa680264 Mon Sep 17 00:00:00 2001
 From: "re:fi.64" <hello@refi64.dev>
 Date: Wed, 28 May 2025 16:41:30 -0500
 Subject: [PATCH] build: Only check rustc_revision when using Chromium's Rust

--- a/patches/chromium/clang-build-script-Support-disabling-the-bundled-libxml2.patch
+++ b/patches/chromium/clang-build-script-Support-disabling-the-bundled-libxml2.patch
@@ -1,4 +1,4 @@
-From 5120768019021725178e9b48968522fbc236c1fb Mon Sep 17 00:00:00 2001
+From b8e224c6c740761987ed58f7fe60ee3a9c1bbc72 Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <rymg19@gmail.com>
 Date: Tue, 1 Mar 2022 19:29:12 -0600
 Subject: [PATCH] clang build script: Support disabling the bundled libxml2

--- a/patches/chromium/media-ffmpeg-Don-t-fail-cross-compilation-on-unsupported-a.patch
+++ b/patches/chromium/media-ffmpeg-Don-t-fail-cross-compilation-on-unsupported-a.patch
@@ -1,4 +1,4 @@
-From 0f7084fe1cd2b5efd261c42593459f329ad17d4d Mon Sep 17 00:00:00 2001
+From 3bfe56153f26993da69bb9d51ec5745a7c1ba837 Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <git@refi64.dev>
 Date: Thu, 16 May 2024 17:02:06 -0500
 Subject: [PATCH] media/ffmpeg: Don't fail cross-compilation on unsupported

--- a/patches/chromium/media-ffmpeg-Skip-formatting-generated-GN-files.patch
+++ b/patches/chromium/media-ffmpeg-Skip-formatting-generated-GN-files.patch
@@ -1,4 +1,4 @@
-From 3917f408e7e1434d5aa28d1443f0576da9cb3c56 Mon Sep 17 00:00:00 2001
+From cfd0d693b4882fa5a502f99271e9842873335ce6 Mon Sep 17 00:00:00 2001
 From: Ryan Gonzalez <git@refi64.dev>
 Date: Thu, 16 May 2024 17:04:22 -0500
 Subject: [PATCH] media/ffmpeg: Skip formatting generated GN files


### PR DESCRIPTION
The current implementation can't fall back to PAC scripts (the portal doesn't even provide that, and it probably shouldn't), and there's no way to disable it if unused. Perhaps it could explicitly use the V8 resolver and then only fallback to the system one, but that would take a non-trivial amount of wiring. Instead, just flip it off for now, unless the user passes `--use-system-proxy-resolver` (the same mechanism used for the newer Windows implementation).

Fixes: #50
Fixes: #173
Fixes: #199
Fixes: #355