### PR TITLE
Allow talking to org.a11y.Bus for screen reader support

### DIFF
--- a/org.chromium.Chromium.yaml
+++ b/org.chromium.Chromium.yaml
@@ -21,6 +21,7 @@ finish-args:
   - --system-talk-name=org.freedesktop.Avahi
   - --system-talk-name=org.freedesktop.UPower
   - --talk-name=com.canonical.AppMenu.Registrar
+  - --talk-name=org.a11y.Bus
   - --talk-name=org.freedesktop.FileManager1
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.ScreenSaver


### PR DESCRIPTION
Screen readers such as Orca receive no output from the Chromium Flatpak because the sandbox does not permit talking to the accessibility bus name on the session bus. 

Add --talk-name=org.a11y.Bus to finish-args. This matches the fix already shipped by other Flatpak apps (e.g. OBS Studio, [obsproject/obs-studio#5869](https://github.com/obsproject/obs-studio/pull/5869)). This is a Flatpak sandbox permission in the manifest, not an application code patch.

### Testing:
With Orca running, verified that speech works after adding the permission (`flatpak run --talk-name=org.a11y.Bus org.chromium.Chromium`) and is silent with `--no-talk-name=org.a11y.Bus.`